### PR TITLE
Build script for generating API JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 tmp
 dist
+repos/

--- a/bin/build-api-json.js
+++ b/bin/build-api-json.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const execSync = require('child_process').execSync;
+const fs = require('fs');
+const path = require('path');
+
+const GIT_REPOS = [
+  ['glimmer-component', 'https://github.com/glimmerjs/glimmer-component'],
+  ['glimmer-application', 'https://github.com/glimmerjs/glimmer-application']
+];
+
+try {
+  fs.mkdirSync('repos');
+} catch (e) { }
+
+GIT_REPOS.forEach(([repoPath, url]) => {
+  let stat;
+  try {
+    stat = fs.statSync(path.join('repos', repoPath));
+  } catch (e) {
+    execSync(`git clone "${url}"`, {
+      cwd: 'repos'
+    });
+  }
+  execSync('git pull --rebase', {
+    cwd: path.join('repos', repoPath)
+  });
+});
+
+execSync('jtd docs-source/docs-config.json');

--- a/docs-source/docs-config.json
+++ b/docs-source/docs-config.json
@@ -1,0 +1,19 @@
+{
+  "manifest": {
+    "title": "Glimmer",
+    "intro": "Everything is awesome"
+  },
+  "projects": [
+    {
+      "src": "repos/glimmer-component/src/",
+      "include": [
+        "Component",
+        "tracked"
+      ]
+    },
+    {
+      "src": "repos/glimmer-application/src/"
+    }
+  ],
+  "output": "docs-source/main.json"
+}


### PR DESCRIPTION
This script adds `bin/build-api-json.js`, which:

1. Clones and/or updates the `@glimmer/component` and `@glimmer/application` repos.
2. Runs `json-typescript-docs` CLI tool to generate the `docs-source/main.json`.