### PR TITLE
Solve issue when refreshing page on a non root route

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -4,7 +4,8 @@ module.exports = function(environment) {
   let ENV = {
     rootURL: '/api/',
     modulePrefix: 'glimmer-api-docs',
-    environment: environment
+    environment: environment,
+    locationType: 'auto'
   };
 
   return ENV;


### PR DESCRIPTION
When accessing directly the following route we get an error from Ember CLI: `/api/projects/_glimmer_component/modules/tracked`

The error is this: ```Cannot GET /api/projects/_glimmer_component/modules/tracked```.

This PR solves that issue.