### PR TITLE
Add service worker

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -38,11 +38,6 @@ module.exports = function(defaults) {
     destDir: '/assets/docs'
   });
 
-  let styles = concat('styles', {
-    inputFiles: ['**/*.css'],
-    outputFile: 'app.css'
-  });
-
   let worker = typescript('workers', {
     tsconfig: {
       compilerOptions: {
@@ -52,14 +47,5 @@ module.exports = function(defaults) {
     }
   });
 
-  // worker = new Rollup(workers, {
-  //   rollup: {
-  //     entry: 'service.js',
-  //     format: 'es',
-  //     dest: 'service.js'
-  //   }
-  // });
-
-  return merge([app.toTree(), extraAssets, styles, worker]);
-  // return app.toTree();
+  return merge([app.toTree(), extraAssets, worker]);
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,6 +3,8 @@ const json = require('broccoli-json-module');
 const Funnel = require('broccoli-funnel');
 const Rollup = require('broccoli-rollup');
 const merge = require('broccoli-merge-trees');
+const concat = require('broccoli-concat');
+const typescript = require('broccoli-typescript-compiler');
 
 module.exports = function(defaults) {
   var app = new GlimmerApp(defaults, {
@@ -36,6 +38,28 @@ module.exports = function(defaults) {
     destDir: '/assets/docs'
   });
 
-  return merge([app.toTree(), extraAssets]);
+  let styles = concat('styles', {
+    inputFiles: ['**/*.css'],
+    outputFile: 'app.css'
+  });
+
+  let worker = typescript('workers', {
+    tsconfig: {
+      compilerOptions: {
+        module: 'es6',
+        target: 'es6'
+      }
+    }
+  });
+
+  // worker = new Rollup(workers, {
+  //   rollup: {
+  //     entry: 'service.js',
+  //     format: 'es',
+  //     dest: 'service.js'
+  //   }
+  // });
+
+  return merge([app.toTree(), extraAssets, styles, worker]);
   // return app.toTree();
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,3 +14,16 @@ export default class App extends Application {
     });
   }
 }
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', function() {
+    navigator.serviceWorker.register('/api/service.js')
+    .then(registration => {
+      // Registration was successful
+      console.log('ServiceWorker registration successful with scope: ', registration.scope);
+    }).catch(function(err) {
+      // registration failed :(
+      console.log('ServiceWorker registration failed: ', err);
+    });
+  });
+}

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -7,14 +7,14 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto|Robot+Mono">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto|Robot+Mono">
     <link rel="stylesheet" href="/api/app.css">
   </head>
   <body>
     <div id="app"></div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/8.3.1/markdown-it.js" integrity="sha256-klTnFwj2rbg4Hl1TfvF7MlndQCHsicH5G/NWhwx5uwU=" crossorigin="anonymous"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/highlight.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/languages/typescript.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/languages/typescript.min.js"></script>
     <script src="/api/assets/docs/main.js"></script>
     <script src="/api/app.js"></script>
   </body>

--- a/workers/service.ts
+++ b/workers/service.ts
@@ -1,12 +1,13 @@
-var CACHE_NAME = 'my-site-cache-v1';
+var CACHE_NAME = 'glimmer-api-docs';
 var urlsToCache = [
   '/api/',
   'app.css',
   'app.js',
   'assets/docs/main.js',
   'https://cdnjs.cloudflare.com/ajax/libs/markdown-it/8.3.1/markdown-it.js',
-  'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/highlight.min.js',
-  'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/languages/typescript.min.js'
+  'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/highlight.min.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/languages/typescript.min.js',
+  'https://fonts.googleapis.com/css?family=Roboto|Robot+Mono'
 ];
 
 self.addEventListener('install', function(event) {
@@ -21,6 +22,7 @@ self.addEventListener('install', function(event) {
 });
 
 self.addEventListener('fetch', function(event) {
+  console.log('fetching', event);
   event.respondWith(
     caches.match(event.request)
       .then(function(response) {

--- a/workers/service.ts
+++ b/workers/service.ts
@@ -1,0 +1,35 @@
+var CACHE_NAME = 'my-site-cache-v1';
+var urlsToCache = [
+  '/api/',
+  'app.css',
+  'app.js',
+  'assets/docs/main.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/markdown-it/8.3.1/markdown-it.js',
+  'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/highlight.min.js',
+  'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/languages/typescript.min.js'
+];
+
+self.addEventListener('install', function(event) {
+  // Perform install steps
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then(function(cache) {
+        console.log('Opened cache');
+        return cache.addAll(urlsToCache);
+      })
+  );
+});
+
+self.addEventListener('fetch', function(event) {
+  event.respondWith(
+    caches.match(event.request)
+      .then(function(response) {
+        // Cache hit - return response
+        if (response) {
+          return response;
+        }
+        return fetch(event.request);
+      }
+    )
+  );
+});

--- a/workers/service.ts
+++ b/workers/service.ts
@@ -22,15 +22,18 @@ self.addEventListener('install', function(event) {
 });
 
 self.addEventListener('fetch', function(event) {
-  console.log('fetching', event);
+  let request = event.request;
+  if (/api\/projects\//.test(request.url)) {
+    request = new Request('/api/');
+  }
   event.respondWith(
-    caches.match(event.request)
+    caches.match(request)
       .then(function(response) {
         // Cache hit - return response
         if (response) {
           return response;
         }
-        return fetch(event.request);
+        return fetch(request);
       }
     )
   );


### PR DESCRIPTION
This builds on #8 and makes sure the service worker responds to all requests to `/api/projects/*` with the cached response for `/api`. This still has quite some room for improvement…