### PR TITLE
fix contrast ratio warning

### DIFF
--- a/src/ui/styles/layout.scss
+++ b/src/ui/styles/layout.scss
@@ -118,7 +118,6 @@ body, html {
   border-top: 1px solid #DDD;
   padding: 10px 16px;
   min-height: 28px;
-  color: #999;
   font-size: 85%;
   background-color: #fff;
 


### PR DESCRIPTION
This fixes a lighthouse warning about contrast ratio:

```
 ── [31m✘[0m Background and foreground colors have a sufficient contrast ratio
      - Rating: critical
      - See: https://dequeuniversity.com/rules/axe/2.1/color-contrast?application=axeAPI
      - Nodes: 1 nodes identified (see HTML output for details)
```