### PR TITLE
Fix docs generation

### DIFF
--- a/bin/build-api-json.js
+++ b/bin/build-api-json.js
@@ -22,7 +22,7 @@ GIT_REPOS.forEach(([repoPath, url]) => {
       cwd: 'repos'
     });
   }
-  execSync('git pull --rebase', {
+  execSync('git pull --rebase && yarn --pure-lockfile', {
     cwd: path.join('repos', repoPath)
   });
 });

--- a/docs-source/main.json
+++ b/docs-source/main.json
@@ -8,69 +8,70 @@
       "intro": "<div><p>Welcome to the Glimmer API documentation.</p><p>Choose a project or module from the table of contents to get started.</p></div>",
       "idMap": {
         "_glimmer_component": {
-          "cachedreference": "123",
-          "component": "94",
-          "componentdefinition": "300",
-          "componentmanager": "246",
-          "componentpathreference": "114",
-          "componentstatebucket": "235",
-          "conditionalreference": "216",
+          "cachedreference": "135",
+          "component": "98",
+          "componentdefinition": "313",
+          "componentmanager": "258",
+          "componentpathreference": "126",
+          "componentstatebucket": "247",
+          "conditionalreference": "228",
           "meta": "1",
-          "nestedpropertyreference": "181",
-          "propertyreference": "148",
-          "rootpropertyreference": "162",
-          "rootreference": "136",
+          "nestedpropertyreference": "193",
+          "propertyreference": "160",
+          "rootpropertyreference": "174",
+          "rootreference": "148",
           "untrackedpropertyerror": "18",
-          "updatablereference": "201",
-          "componentfactory": "110",
-          "constructoroptions": "233",
+          "updatablereference": "213",
+          "componentfactory": "122",
+          "constructoroptions": "245",
           "interceptors": "15",
-          "untrackedpropertyerrorthrower": "30",
-          "builderror": "229",
-          "combinatorforcomputedproperties": "55",
-          "defaulterrorthrower": "80",
-          "descriptorfortrackedcomputedproperty": "44",
-          "hasownproperty": "65",
-          "hastag": "76",
-          "installdevmodeerrorinterceptor": "89",
-          "installtrackedproperty": "51",
-          "metafor": "61",
-          "propertydidchange": "69",
-          "setpropertydidchange": "71",
-          "tagforproperty": "84",
-          "tracked": "34"
+          "untrackedpropertyerrorthrower": "34",
+          "builderror": "241",
+          "combinatorforcomputedproperties": "59",
+          "defaulterrorthrower": "84",
+          "descriptorfortrackedcomputedproperty": "48",
+          "hasownproperty": "69",
+          "hastag": "80",
+          "installdevmodeerrorinterceptor": "93",
+          "installtrackedproperty": "55",
+          "metafor": "65",
+          "propertydidchange": "73",
+          "setpropertydidchange": "75",
+          "tagforproperty": "88",
+          "tracked": "38"
         },
         "_glimmer_application": {
-          "application": "698",
-          "applicationregistry": "318",
-          "arrayiterator": "384",
-          "defaultcomponentdefinition": "543",
-          "dynamiccomponentreference": "456",
-          "dynamicscope": "370",
-          "emptyiterator": "410",
-          "environment": "554",
-          "helperreference": "519",
-          "iterable": "415",
-          "objectkeysiterator": "396",
-          "simplepathreference": "505",
-          "approot": "693",
-          "applicationoptions": "685",
-          "componentdefinitioncreator": "450",
-          "environmentoptions": "540",
-          "extendedtemplatemeta": "445",
-          "initializer": "688",
-          "blockcomponentmacro": "470",
-          "buildaction": "491",
-          "builduserhelper": "537",
-          "cancreatecomponentdefinition": "682",
-          "debuginfoforreference": "499",
-          "debugname": "502",
-          "dynamiccomponentfor": "483",
-          "hashtoargs": "488",
-          "inlinecomponentmacro": "477",
-          "istypespecifier": "367",
-          "populatemacros": "678",
-          "thrownoactionerror": "495"
+          "application": "712",
+          "applicationregistry": "331",
+          "arrayiterator": "397",
+          "defaultcomponentdefinition": "556",
+          "dynamiccomponentreference": "469",
+          "dynamicscope": "383",
+          "emptyiterator": "423",
+          "environment": "567",
+          "helperreference": "532",
+          "iterable": "428",
+          "objectkeysiterator": "409",
+          "simplepathreference": "518",
+          "approot": "707",
+          "applicationoptions": "698",
+          "componentdefinitioncreator": "463",
+          "environmentoptions": "553",
+          "extendedtemplatemeta": "458",
+          "initializer": "702",
+          "noop": "771",
+          "blockcomponentmacro": "483",
+          "buildaction": "504",
+          "builduserhelper": "550",
+          "cancreatecomponentdefinition": "695",
+          "debuginfoforreference": "512",
+          "debugname": "515",
+          "dynamiccomponentfor": "496",
+          "hashtoargs": "501",
+          "inlinecomponentmacro": "490",
+          "istypespecifier": "380",
+          "populatemacros": "691",
+          "thrownoactionerror": "508"
         }
       }
     },
@@ -101,10 +102,10 @@
         },
         "alias": "_glimmer_component",
         "fullName": "@glimmer/component",
-        "hierarchy": "Global @glimmer/component\n  Class CachedReference<T>\n    TypeParameter T\n    Property _lastRevision:number | null\n    Property _lastValue:any\n    Accessor tag\n      GetSignature __get:Tag\n    Method compute\n      CallSignature compute:T\n    Method get\n      CallSignature get:PathReference<any>\n        Parameter key:string\n    Method value\n      CallSignature value:any\n  Class Component\n    Constructor constructor\n      ConstructorSignature new Component:Component\n        Parameter options:object\n    Property args:object\n    Property debugName:string\n    Property element:Element\n    Method didInsertElement\n      CallSignature didInsertElement:void\n    Method didUpdate\n      CallSignature didUpdate:void\n    Method toString\n      CallSignature toString:string\n    Method create\n      CallSignature create:Component\n        Parameter injections:any\n  Class ComponentDefinition\n    Constructor constructor\n      ConstructorSignature new ComponentDefinition:ComponentDefinition\n        Parameter name:string\n        Parameter manager:ComponentManager\n        Parameter template:Template<TemplateMeta>\n        Parameter componentFactory:ComponentFactory\n    Property ComponentClass:ComponentClass\n    Property args:CapturedArguments\n    Property componentFactory:ComponentFactory\n    Property manager:ComponentManager<ComponentStateBucket>\n    Property name:string\n    Property template:Template<TemplateMeta>\n    Method toJSON\n      CallSignature toJSON:object\n        TypeLiteral __type\n          Variable GlimmerDebug:string\n  Class ComponentManager\n    Constructor constructor\n      ConstructorSignature new ComponentManager:ComponentManager\n        Parameter options:ConstructorOptions\n    Property env:Environment\n    Method create\n      CallSignature create:ComponentStateBucket | null\n        Parameter environment:Environment\n        Parameter definition:ComponentDefinition\n        Parameter volatileArgs:Arguments\n    Method createComponentDefinition\n      CallSignature createComponentDefinition:ComponentDefinition\n        Parameter name:string\n        Parameter template:Template<any>\n        Parameter componentFactory:Factory<Component>\n    Method didCreate\n      CallSignature didCreate:void\n        Parameter bucket:ComponentStateBucket\n    Method didCreateElement\n      CallSignature didCreateElement:void\n        Parameter bucket:ComponentStateBucket\n        Parameter element:Element\n    Method didRenderLayout\n      CallSignature didRenderLayout:void\n        Parameter bucket:ComponentStateBucket\n        Parameter bounds:Bounds\n    Method didUpdate\n      CallSignature didUpdate:void\n        Parameter bucket:ComponentStateBucket\n    Method didUpdateLayout\n      CallSignature didUpdateLayout:void\n    Method getDestructor\n      CallSignature getDestructor:null\n    Method getSelf\n      CallSignature getSelf:RootReference\n        Parameter bucket:ComponentStateBucket\n    Method getTag\n      CallSignature getTag:null\n    Method layoutFor\n      CallSignature layoutFor:CompiledDynamicProgram\n        Parameter definition:ComponentDefinition\n        Parameter bucket:ComponentStateBucket\n        Parameter env:Environment\n    Method prepareArgs\n      CallSignature prepareArgs:null\n        Parameter definition:ComponentDefinition\n        Parameter args:Arguments\n    Method update\n      CallSignature update:void\n        Parameter bucket:ComponentStateBucket\n        Parameter scope:DynamicScope\n    Method create\n      CallSignature create:ComponentManager\n        Parameter options:ConstructorOptions\n  Class ComponentPathReference<T>\n    TypeParameter T\n    Accessor tag\n      GetSignature __get:Tag\n    Method get\n      CallSignature get:PathReference<any>\n        Parameter key:string\n    Method value\n      CallSignature value:T\n  Class ComponentStateBucket\n    Constructor constructor\n      ConstructorSignature new ComponentStateBucket:ComponentStateBucket\n        Parameter definition:ComponentDefinition\n        Parameter args:CapturedArguments\n        Parameter owner:Owner\n    Property args:CapturedArguments\n    Property component:Component\n    Property name:string\n    Method namedArgsSnapshot\n      CallSignature namedArgsSnapshot:Readonly<Dict<any | void>>\n  Class ConditionalReference\n    Constructor constructor\n      ConstructorSignature new ConditionalReference:ConditionalReference\n        Parameter inner:Reference<Opaque>\n    Property tag:Tag\n    Method toBool\n      CallSignature toBool:boolean\n        Parameter value:Opaque\n    Method value\n      CallSignature value:boolean\n    Method create\n      CallSignature create:PrimitiveReference<any> | ConditionalReference\n        Parameter reference:PathReference<any>\n  Class Meta\n    Constructor constructor\n      ConstructorSignature new Meta:Meta\n        Parameter parent:Meta\n    Property computedPropertyTags:Dict<TagWrapper<DirtyableTag>>\n    Property tags:Dict<Tag>\n    Property trackedProperties:Dict<boolean>\n    Property trackedPropertyDependencies:Dict<string[]>\n    Method dirtyableTagFor\n      CallSignature dirtyableTagFor:TagWrapper<DirtyableTag>\n        Parameter key:Key\n    Method tagFor\n      CallSignature tagFor:Tag\n        Parameter key:Key\n  Class NestedPropertyReference\n    Constructor constructor\n      ConstructorSignature new NestedPropertyReference:NestedPropertyReference\n        Parameter parentReference:PathReference<any>\n        Parameter propertyKey:string\n    Property _parentObjectTag:TagWrapper<UpdatableTag>\n    Property _parentReference:PathReference<any>\n    Property _propertyKey:string\n    Property tag:Tag\n    Method compute\n      CallSignature compute:any\n    Method get\n      CallSignature get:PathReference<any>\n        Parameter key:string\n    Method value\n      CallSignature value:any\n    Method create\n      CallSignature create:RootPropertyReference | NestedPropertyReference\n        Parameter parentReference:PathReference<any>\n        Parameter propertyKey:string\n  Class PropertyReference\n    Accessor tag\n      GetSignature __get:Tag\n    Method compute\n      CallSignature compute:any\n    Method get\n      CallSignature get:PathReference<any>\n        Parameter key:string\n    Method value\n      CallSignature value:any\n    Method create\n      CallSignature create:RootPropertyReference | NestedPropertyReference\n        Parameter parentReference:PathReference<any>\n        Parameter propertyKey:string\n  Class RootPropertyReference\n    Constructor constructor\n      ConstructorSignature new RootPropertyReference:RootPropertyReference\n        Parameter parentValue:object\n        Parameter propertyKey:string\n    Property _parentValue:object\n    Property _propertyKey:string\n    Property tag:Tag\n    Method compute\n      CallSignature compute:any\n    Method get\n      CallSignature get:PathReference<any>\n        Parameter key:string\n    Method value\n      CallSignature value:any\n    Method create\n      CallSignature create:RootPropertyReference | NestedPropertyReference\n        Parameter parentReference:PathReference<any>\n        Parameter propertyKey:string\n  Class RootReference\n    Constructor constructor\n      ConstructorSignature new RootReference:RootReference\n        Parameter inner:any\n    Property children:Dict<RootPropertyReference>\n    Property inner:any\n    Property tag:Tag\n    Method get\n      CallSignature get:RootPropertyReference\n        Parameter propertyKey:string\n    Method value\n      CallSignature value:any\n  Class UntrackedPropertyError\n    Constructor constructor\n      ConstructorSignature new UntrackedPropertyError:UntrackedPropertyError\n        Parameter target:any\n        Parameter key:string\n        Parameter message:string\n    Property key:string\n    Property target:any\n    Property Error:ErrorConstructor\n    Property message:string\n    Property name:string\n    Property stack:string\n  Class UpdatableReference<T>\n    TypeParameter T\n    Constructor constructor\n      ConstructorSignature new UpdatableReference:UpdatableReference\n        Parameter value:T\n    Property _value:T\n    Property tag:TagWrapper<DirtyableTag>\n    Method get\n      CallSignature get:PathReference<any>\n        Parameter key:string\n    Method update\n      CallSignature update:void\n        Parameter value:T\n    Method value\n      CallSignature value:T\n  Interface ComponentFactory\n    Method create\n      CallSignature create:Component\n        Parameter injections:object\n  Interface ConstructorOptions\n    Property env:Environment\n  Interface Interceptors\n    IndexSignature __index:boolean\n      Parameter key:string\n  Interface UntrackedPropertyErrorThrower\n    CallSignature __call:void\n      Parameter obj:any\n      Parameter key:string\n  TypeAlias Key:string\n  Variable META:symbol\n  Variable hOP:hasOwnProperty\n  Function buildError\n    CallSignature buildError:void\n      Parameter obj:any\n      Parameter key:string\n  Function combinatorForComputedProperties\n    CallSignature combinatorForComputedProperties:Tag\n      Parameter meta:Meta\n      Parameter key:Key\n      Parameter dependencies:Key[] | void\n  Function defaultErrorThrower\n    CallSignature defaultErrorThrower:UntrackedPropertyError\n      Parameter obj:any\n      Parameter key:string\n  Function descriptorForTrackedComputedProperty\n    CallSignature descriptorForTrackedComputedProperty:PropertyDescriptor\n      Parameter target:any\n      Parameter key:any\n      Parameter descriptor:PropertyDescriptor\n      Parameter dependencies:string[]\n  Function hasOwnProperty\n    CallSignature hasOwnProperty:any\n      Parameter obj:any\n      Parameter key:symbol\n  Function hasTag\n    CallSignature hasTag:boolean\n      Parameter obj:any\n      Parameter key:string\n  Function installDevModeErrorInterceptor\n    CallSignature installDevModeErrorInterceptor:void\n      Parameter obj:object\n      Parameter key:string\n      Parameter throwError:UntrackedPropertyErrorThrower\n  Function installTrackedProperty\n    CallSignature installTrackedProperty:void\n      Parameter target:any\n      Parameter key:Key\n  Function metaFor\n    CallSignature metaFor:Meta\n      Parameter obj:any\n  Function propertyDidChange\n    CallSignature propertyDidChange:void\n  Function setPropertyDidChange\n    CallSignature setPropertyDidChange:void\n      Parameter cb:function\n        TypeLiteral __type\n          CallSignature __call:void\n  Function tagForProperty\n    CallSignature tagForProperty:Tag\n      Parameter obj:any\n      Parameter key:string\n      Parameter throwError:UntrackedPropertyErrorThrower\n  Function tracked\n    CallSignature tracked:MethodDecorator\n      Parameter dependencies:string[]\n    CallSignature tracked:any\n      Parameter target:any\n      Parameter key:any\n    CallSignature tracked:PropertyDescriptor\n      Parameter target:any\n      Parameter key:any\n      Parameter descriptor:PropertyDescriptor",
+        "hierarchy": "Global @glimmer/component\n  Class CachedReference<T>\n    TypeParameter T\n    Property _lastRevision:number | null\n    Property _lastValue:any\n    Accessor tag\n      GetSignature __get:Tag\n    Method compute\n      CallSignature compute:T\n    Method get\n      CallSignature get:PathReference<any>\n        Parameter key:string\n    Method value\n      CallSignature value:any\n  Class Component\n    Constructor constructor\n      ConstructorSignature new Component:Component\n        Parameter options:object\n    Property ___args__:any\n    Property debugName:string\n    Property element:Element\n    Accessor args\n      GetSignature __get:any\n      SetSignature __set:void\n        Parameter args:any\n    Method destroy\n      CallSignature destroy:void\n    Method didInsertElement\n      CallSignature didInsertElement:void\n    Method didUpdate\n      CallSignature didUpdate:void\n    Method toString\n      CallSignature toString:string\n    Method willDestroy\n      CallSignature willDestroy:void\n    Method create\n      CallSignature create:Component\n        Parameter injections:any\n  Class ComponentDefinition\n    Constructor constructor\n      ConstructorSignature new ComponentDefinition:ComponentDefinition\n        Parameter name:string\n        Parameter manager:ComponentManager\n        Parameter template:Template<TemplateMeta>\n        Parameter componentFactory:ComponentFactory\n    Property ComponentClass:ComponentClass\n    Property args:CapturedArguments\n    Property componentFactory:ComponentFactory\n    Property manager:ComponentManager<ComponentStateBucket>\n    Property name:string\n    Property template:Template<TemplateMeta>\n    Method toJSON\n      CallSignature toJSON:object\n        TypeLiteral __type\n          Variable GlimmerDebug:string\n  Class ComponentManager\n    Constructor constructor\n      ConstructorSignature new ComponentManager:ComponentManager\n        Parameter options:ConstructorOptions\n    Property env:Environment\n    Method create\n      CallSignature create:ComponentStateBucket | null\n        Parameter environment:Environment\n        Parameter definition:ComponentDefinition\n        Parameter volatileArgs:Arguments\n    Method createComponentDefinition\n      CallSignature createComponentDefinition:ComponentDefinition\n        Parameter name:string\n        Parameter template:Template<any>\n        Parameter componentFactory:Factory<Component>\n    Method didCreate\n      CallSignature didCreate:void\n        Parameter bucket:ComponentStateBucket\n    Method didCreateElement\n      CallSignature didCreateElement:void\n        Parameter bucket:ComponentStateBucket\n        Parameter element:Element\n    Method didRenderLayout\n      CallSignature didRenderLayout:void\n        Parameter bucket:ComponentStateBucket\n        Parameter bounds:Bounds\n    Method didUpdate\n      CallSignature didUpdate:void\n        Parameter bucket:ComponentStateBucket\n    Method didUpdateLayout\n      CallSignature didUpdateLayout:void\n    Method getDestructor\n      CallSignature getDestructor:Destroyable\n        Parameter bucket:ComponentStateBucket\n    Method getSelf\n      CallSignature getSelf:RootReference\n        Parameter bucket:ComponentStateBucket\n    Method getTag\n      CallSignature getTag:null\n    Method layoutFor\n      CallSignature layoutFor:CompiledDynamicProgram\n        Parameter definition:ComponentDefinition\n        Parameter bucket:ComponentStateBucket\n        Parameter env:Environment\n    Method prepareArgs\n      CallSignature prepareArgs:null\n        Parameter definition:ComponentDefinition\n        Parameter args:Arguments\n    Method update\n      CallSignature update:void\n        Parameter bucket:ComponentStateBucket\n        Parameter scope:DynamicScope\n    Method create\n      CallSignature create:ComponentManager\n        Parameter options:ConstructorOptions\n  Class ComponentPathReference<T>\n    TypeParameter T\n    Accessor tag\n      GetSignature __get:Tag\n    Method get\n      CallSignature get:PathReference<any>\n        Parameter key:string\n    Method value\n      CallSignature value:T\n  Class ComponentStateBucket\n    Constructor constructor\n      ConstructorSignature new ComponentStateBucket:ComponentStateBucket\n        Parameter definition:ComponentDefinition\n        Parameter args:CapturedArguments\n        Parameter owner:Owner\n    Property args:CapturedArguments\n    Property component:Component\n    Property name:string\n    Method namedArgsSnapshot\n      CallSignature namedArgsSnapshot:Readonly<Dict<any | void>>\n  Class ConditionalReference\n    Constructor constructor\n      ConstructorSignature new ConditionalReference:ConditionalReference\n        Parameter inner:Reference<Opaque>\n    Property tag:Tag\n    Method toBool\n      CallSignature toBool:boolean\n        Parameter value:Opaque\n    Method value\n      CallSignature value:boolean\n    Method create\n      CallSignature create:PrimitiveReference<any> | ConditionalReference\n        Parameter reference:PathReference<any>\n  Class Meta\n    Constructor constructor\n      ConstructorSignature new Meta:Meta\n        Parameter parent:Meta\n    Property computedPropertyTags:Dict<TagWrapper<DirtyableTag>>\n    Property tags:Dict<Tag>\n    Property trackedProperties:Dict<boolean>\n    Property trackedPropertyDependencies:Dict<string[]>\n    Method dirtyableTagFor\n      CallSignature dirtyableTagFor:TagWrapper<DirtyableTag>\n        Parameter key:Key\n    Method tagFor\n      CallSignature tagFor:Tag\n        Parameter key:Key\n  Class NestedPropertyReference\n    Constructor constructor\n      ConstructorSignature new NestedPropertyReference:NestedPropertyReference\n        Parameter parentReference:PathReference<any>\n        Parameter propertyKey:string\n    Property _parentObjectTag:TagWrapper<UpdatableTag>\n    Property _parentReference:PathReference<any>\n    Property _propertyKey:string\n    Property tag:Tag\n    Method compute\n      CallSignature compute:any\n    Method get\n      CallSignature get:PathReference<any>\n        Parameter key:string\n    Method value\n      CallSignature value:any\n    Method create\n      CallSignature create:RootPropertyReference | NestedPropertyReference\n        Parameter parentReference:PathReference<any>\n        Parameter propertyKey:string\n  Class PropertyReference\n    Accessor tag\n      GetSignature __get:Tag\n    Method compute\n      CallSignature compute:any\n    Method get\n      CallSignature get:PathReference<any>\n        Parameter key:string\n    Method value\n      CallSignature value:any\n    Method create\n      CallSignature create:RootPropertyReference | NestedPropertyReference\n        Parameter parentReference:PathReference<any>\n        Parameter propertyKey:string\n  Class RootPropertyReference\n    Constructor constructor\n      ConstructorSignature new RootPropertyReference:RootPropertyReference\n        Parameter parentValue:object\n        Parameter propertyKey:string\n    Property _parentValue:object\n    Property _propertyKey:string\n    Property tag:Tag\n    Method compute\n      CallSignature compute:any\n    Method get\n      CallSignature get:PathReference<any>\n        Parameter key:string\n    Method value\n      CallSignature value:any\n    Method create\n      CallSignature create:RootPropertyReference | NestedPropertyReference\n        Parameter parentReference:PathReference<any>\n        Parameter propertyKey:string\n  Class RootReference\n    Constructor constructor\n      ConstructorSignature new RootReference:RootReference\n        Parameter inner:any\n    Property children:Dict<RootPropertyReference>\n    Property inner:any\n    Property tag:Tag\n    Method get\n      CallSignature get:RootPropertyReference\n        Parameter propertyKey:string\n    Method value\n      CallSignature value:any\n  Class UntrackedPropertyError\n    Constructor constructor\n      ConstructorSignature new UntrackedPropertyError:UntrackedPropertyError\n        Parameter target:any\n        Parameter key:string\n        Parameter message:string\n    Property key:string\n    Property target:any\n    Property Error:ErrorConstructor\n    Property message:string\n    Property name:string\n    Property stack:string\n    Method for\n      CallSignature for:UntrackedPropertyError\n        Parameter obj:any\n        Parameter key:string\n  Class UpdatableReference<T>\n    TypeParameter T\n    Constructor constructor\n      ConstructorSignature new UpdatableReference:UpdatableReference\n        Parameter value:T\n    Property _value:T\n    Property tag:TagWrapper<DirtyableTag>\n    Method get\n      CallSignature get:PathReference<any>\n        Parameter key:string\n    Method update\n      CallSignature update:void\n        Parameter value:T\n    Method value\n      CallSignature value:T\n  Interface ComponentFactory\n    Method create\n      CallSignature create:Component\n        Parameter injections:object\n  Interface ConstructorOptions\n    Property env:Environment\n  Interface Interceptors\n    IndexSignature __index:boolean\n      Parameter key:string\n  Interface UntrackedPropertyErrorThrower\n    CallSignature __call:void\n      Parameter obj:any\n      Parameter key:string\n  TypeAlias Key:string\n  Variable META:symbol\n  Variable hOP:hasOwnProperty\n  Function buildError\n    CallSignature buildError:void\n      Parameter obj:any\n      Parameter key:string\n  Function combinatorForComputedProperties\n    CallSignature combinatorForComputedProperties:Tag\n      Parameter meta:Meta\n      Parameter key:Key\n      Parameter dependencies:Key[] | void\n  Function defaultErrorThrower\n    CallSignature defaultErrorThrower:UntrackedPropertyError\n      Parameter obj:any\n      Parameter key:string\n  Function descriptorForTrackedComputedProperty\n    CallSignature descriptorForTrackedComputedProperty:PropertyDescriptor\n      Parameter target:any\n      Parameter key:any\n      Parameter descriptor:PropertyDescriptor\n      Parameter dependencies:string[]\n  Function hasOwnProperty\n    CallSignature hasOwnProperty:any\n      Parameter obj:any\n      Parameter key:symbol\n  Function hasTag\n    CallSignature hasTag:boolean\n      Parameter obj:any\n      Parameter key:string\n  Function installDevModeErrorInterceptor\n    CallSignature installDevModeErrorInterceptor:void\n      Parameter obj:object\n      Parameter key:string\n      Parameter throwError:UntrackedPropertyErrorThrower\n  Function installTrackedProperty\n    CallSignature installTrackedProperty:void\n      Parameter target:any\n      Parameter key:Key\n  Function metaFor\n    CallSignature metaFor:Meta\n      Parameter obj:any\n  Function propertyDidChange\n    CallSignature propertyDidChange:void\n  Function setPropertyDidChange\n    CallSignature setPropertyDidChange:void\n      Parameter cb:function\n        TypeLiteral __type\n          CallSignature __call:void\n  Function tagForProperty\n    CallSignature tagForProperty:Tag\n      Parameter obj:any\n      Parameter key:string\n      Parameter throwError:UntrackedPropertyErrorThrower\n  Function tracked\n    CallSignature tracked:MethodDecorator\n      Parameter dependencies:string[]\n    CallSignature tracked:any\n      Parameter target:any\n      Parameter key:any\n    CallSignature tracked:PropertyDescriptor\n      Parameter target:any\n      Parameter key:any\n      Parameter descriptor:PropertyDescriptor",
         "packageInfo": {
           "name": "@glimmer/component",
-          "version": "0.3.8",
+          "version": "0.3.10",
           "description": "Glimmer component library",
           "contributors": [
             "Dan Gebhardt <dan@cerebris.com>",
@@ -123,14 +124,17 @@
             "preversion": "npm run test",
             "prepublish": "npm run build",
             "postpublish": "git push origin master --tags",
-            "test": "ember test"
+            "test": "npm run test:prod",
+            "test:prod": "TEST_MODE=prod ember test",
+            "test:debug": "TEST_MODE=debug ember test"
           },
           "dependencies": {
-            "@glimmer/util": "^0.23.0-alpha.11",
             "@glimmer/application": "^0.3.6",
             "@glimmer/di": "^0.1.9",
+            "@glimmer/env": "^0.1.5",
             "@glimmer/reference": "^0.23.0-alpha.11",
-            "@glimmer/runtime": "^0.23.0-alpha.11"
+            "@glimmer/runtime": "^0.23.0-alpha.11",
+            "@glimmer/util": "^0.23.0-alpha.11"
           },
           "devDependencies": {
             "@glimmer/build": "^0.6.1",
@@ -140,6 +144,7 @@
             "@glimmer/wire-format": "^0.23.0-alpha.11",
             "broccoli": "^1.1.0",
             "broccoli-cli": "^1.0.0",
+            "broccoli-file-creator": "^1.1.1",
             "ember-cli": "^2.12.0",
             "testem": "^1.13.0"
           }
@@ -165,9 +170,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 52,
+                "line": 53,
                 "character": 15,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L52"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L53"
               }
             ],
             "typeInfo": {
@@ -196,9 +201,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 180,
+                "line": 181,
                 "character": 8,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L180"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L181"
               }
             ],
             "typeInfo": {
@@ -225,9 +230,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 191,
+                "line": 192,
                 "character": 7,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L191"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L192"
               }
             ],
             "typeInfo": {
@@ -248,31 +253,31 @@
           "data": [
             {
               "type": "class",
-              "id": "123"
+              "id": "135"
             },
             {
               "type": "class",
-              "id": "94"
+              "id": "98"
             },
             {
               "type": "class",
-              "id": "300"
+              "id": "313"
             },
             {
               "type": "class",
-              "id": "246"
+              "id": "258"
             },
             {
               "type": "class",
-              "id": "114"
+              "id": "126"
             },
             {
               "type": "class",
-              "id": "235"
+              "id": "247"
             },
             {
               "type": "class",
-              "id": "216"
+              "id": "228"
             },
             {
               "type": "class",
@@ -280,7 +285,15 @@
             },
             {
               "type": "class",
-              "id": "181"
+              "id": "193"
+            },
+            {
+              "type": "class",
+              "id": "160"
+            },
+            {
+              "type": "class",
+              "id": "174"
             },
             {
               "type": "class",
@@ -288,19 +301,11 @@
             },
             {
               "type": "class",
-              "id": "162"
-            },
-            {
-              "type": "class",
-              "id": "136"
-            },
-            {
-              "type": "class",
               "id": "18"
             },
             {
               "type": "class",
-              "id": "201"
+              "id": "213"
             }
           ]
         },
@@ -308,11 +313,11 @@
           "data": [
             {
               "type": "interface",
-              "id": "110"
+              "id": "122"
             },
             {
               "type": "interface",
-              "id": "233"
+              "id": "245"
             },
             {
               "type": "interface",
@@ -320,7 +325,7 @@
             },
             {
               "type": "interface",
-              "id": "30"
+              "id": "34"
             }
           ]
         },
@@ -328,47 +333,11 @@
           "data": [
             {
               "type": "function",
-              "id": "229"
+              "id": "241"
             },
             {
               "type": "function",
-              "id": "55"
-            },
-            {
-              "type": "function",
-              "id": "80"
-            },
-            {
-              "type": "function",
-              "id": "44"
-            },
-            {
-              "type": "function",
-              "id": "65"
-            },
-            {
-              "type": "function",
-              "id": "76"
-            },
-            {
-              "type": "function",
-              "id": "89"
-            },
-            {
-              "type": "function",
-              "id": "51"
-            },
-            {
-              "type": "function",
-              "id": "61"
-            },
-            {
-              "type": "function",
-              "id": "69"
-            },
-            {
-              "type": "function",
-              "id": "71"
+              "id": "59"
             },
             {
               "type": "function",
@@ -376,14 +345,50 @@
             },
             {
               "type": "function",
-              "id": "34"
+              "id": "48"
+            },
+            {
+              "type": "function",
+              "id": "69"
+            },
+            {
+              "type": "function",
+              "id": "80"
+            },
+            {
+              "type": "function",
+              "id": "93"
+            },
+            {
+              "type": "function",
+              "id": "55"
+            },
+            {
+              "type": "function",
+              "id": "65"
+            },
+            {
+              "type": "function",
+              "id": "73"
+            },
+            {
+              "type": "function",
+              "id": "75"
+            },
+            {
+              "type": "function",
+              "id": "88"
+            },
+            {
+              "type": "function",
+              "id": "38"
             }
           ]
         }
       }
     },
     {
-      "id": "123",
+      "id": "135",
       "type": "class",
       "attributes": {
         "name": "CachedReference",
@@ -413,7 +418,7 @@
             "isArray": false,
             "name": "ComponentPathReference",
             "link": {
-              "id": "114",
+              "id": "126",
               "type": "class",
               "slug": "componentpathreference",
               "sources": [
@@ -421,7 +426,7 @@
                   "fileName": "references.ts",
                   "line": 24,
                   "character": 44,
-                  "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L24"
+                  "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L24"
                 }
               ],
               "parent": {
@@ -438,7 +443,7 @@
             "fileName": "references.ts",
             "line": 33,
             "character": 37,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L33"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L33"
           }
         ],
         "typeParameters": [
@@ -474,7 +479,7 @@
                 "fileName": "references.ts",
                 "line": 34,
                 "character": 23,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L34"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L34"
               }
             ],
             "typeInfo": {
@@ -513,7 +518,7 @@
                 "fileName": "references.ts",
                 "line": 35,
                 "character": 20,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L35"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L35"
               }
             ],
             "typeInfo": {
@@ -544,7 +549,7 @@
                 "fileName": "references.ts",
                 "line": 26,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L26"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L26"
               }
             ],
             "getSignatures": [
@@ -561,7 +566,7 @@
                     "fileName": "references.ts",
                     "line": 26,
                     "character": 18,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L26"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L26"
                   }
                 ],
                 "typeInfo": {
@@ -594,7 +599,7 @@
                 "fileName": "references.ts",
                 "line": 37,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L37"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L37"
               }
             ],
             "callSignatures": [
@@ -611,7 +616,7 @@
                     "fileName": "references.ts",
                     "line": 37,
                     "character": 18,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L37"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L37"
                   }
                 ],
                 "typeInfo": {
@@ -642,7 +647,7 @@
                 "fileName": "references.ts",
                 "line": 28,
                 "character": 5,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L28"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L28"
               }
             ],
             "callSignatures": [
@@ -659,7 +664,7 @@
                     "fileName": "references.ts",
                     "line": 28,
                     "character": 5,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L28"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L28"
                   }
                 ],
                 "typeInfo": {
@@ -708,7 +713,7 @@
                 "fileName": "references.ts",
                 "line": 39,
                 "character": 7,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L39"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L39"
               }
             ],
             "callSignatures": [
@@ -725,7 +730,7 @@
                     "fileName": "references.ts",
                     "line": 39,
                     "character": 7,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L39"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L39"
                   }
                 ],
                 "typeInfo": {
@@ -739,7 +744,7 @@
       }
     },
     {
-      "id": "94",
+      "id": "98",
       "type": "class",
       "attributes": {
         "name": "Component",
@@ -756,14 +761,14 @@
         },
         "alias": "component",
         "fullName": "Component",
-        "hierarchy": "Class Component\n  Constructor constructor\n    ConstructorSignature new Component:Component\n      Parameter options:object\n  Property args:object\n  Property debugName:string\n  Property element:Element\n  Method didInsertElement\n    CallSignature didInsertElement:void\n  Method didUpdate\n    CallSignature didUpdate:void\n  Method toString\n    CallSignature toString:string\n  Method create\n    CallSignature create:Component\n      Parameter injections:any",
+        "hierarchy": "Class Component\n  Constructor constructor\n    ConstructorSignature new Component:Component\n      Parameter options:object\n  Property ___args__:any\n  Property debugName:string\n  Property element:Element\n  Accessor args\n    GetSignature __get:any\n    SetSignature __set:void\n      Parameter args:any\n  Method destroy\n    CallSignature destroy:void\n  Method didInsertElement\n    CallSignature didInsertElement:void\n  Method didUpdate\n    CallSignature didUpdate:void\n  Method toString\n    CallSignature toString:string\n  Method willDestroy\n    CallSignature willDestroy:void\n  Method create\n    CallSignature create:Component\n      Parameter injections:any",
         "kindString": "Class",
         "sources": [
           {
             "fileName": "component.ts",
             "line": 127,
             "character": 15,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L127"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L127"
           }
         ],
         "comment": {
@@ -790,9 +795,9 @@
             "sources": [
               {
                 "fileName": "component.ts",
-                "line": 169,
+                "line": 181,
                 "character": 3,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L169"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L181"
               }
             ],
             "comment": {
@@ -812,9 +817,9 @@
                 "sources": [
                   {
                     "fileName": "component.ts",
-                    "line": 169,
+                    "line": 181,
                     "character": 3,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L169"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L181"
                   }
                 ],
                 "comment": {
@@ -826,7 +831,7 @@
                   "isArray": false,
                   "name": "Component",
                   "link": {
-                    "id": "94",
+                    "id": "98",
                     "type": "class",
                     "slug": "component",
                     "sources": [
@@ -834,7 +839,7 @@
                         "fileName": "component.ts",
                         "line": 127,
                         "character": 15,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L127"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L127"
                       }
                     ],
                     "parent": {
@@ -869,36 +874,37 @@
         ],
         "properties": [
           {
-            "name": "args",
-            "slug": "args",
+            "name": "___args__",
+            "slug": "___args__",
             "flags": {
               "isExported": true,
               "isExternal": true,
               "isOptional": false,
-              "isPrivate": false,
+              "isPrivate": true,
               "isPublic": false,
               "isProtected": false,
               "isStatic": false
             },
-            "alias": "args",
-            "fullName": "Component.args",
-            "hierarchy": "Property args:object",
+            "alias": "___args__",
+            "fullName": "Component.___args__",
+            "hierarchy": "Property ___args__:any",
             "kindString": "Property",
             "sources": [
               {
                 "fileName": "component.ts",
-                "line": 165,
-                "character": 15,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L165"
+                "line": 177,
+                "character": 18,
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L177"
               }
             ],
             "comment": {
-              "shortText": "<p>Named arguments passed to the component from its parent component.\nThey can be accessed in JavaScript via <code>this.args.argumentName</code> and in the template via <code>@argumentName</code>.</p>\n",
-              "text": "<p>Say you have the following component, which will have two <code>args</code>, <code>firstName</code> and <code>lastName</code>:</p>\n<pre><code class=\"lang-hbs\"><span class=\"xml\"><span class=\"hljs-tag\">&lt;<span class=\"hljs-name\">my-component</span> @<span class=\"hljs-attr\">firstName</span>=<span class=\"hljs-string\">\"Arthur\"</span> @<span class=\"hljs-attr\">lastName</span>=<span class=\"hljs-string\">\"Dent\"</span> /&gt;</span></span>\n</code></pre>\n<p>If you needed to calculate <code>fullName</code> by combining both of them, you would do:</p>\n<pre><code class=\"lang-ts\">didInsertElement() {\n  <span class=\"hljs-built_in\">console</span>.log(<span class=\"hljs-string\">`Hi, my full name is <span class=\"hljs-subst\">${this.args.firstName}</span> <span class=\"hljs-subst\">${this.args.lastName}</span>`</span>);\n}\n</code></pre>\n<p>While in the template you could do:</p>\n<pre><code class=\"lang-hbs\"><span class=\"xml\"><span class=\"hljs-tag\">&lt;<span class=\"hljs-name\">p</span>&gt;</span>Welcome, </span><span class=\"hljs-template-variable\">{{@firstName}}</span><span class=\"xml\"> </span><span class=\"hljs-template-variable\">{{@lastName}}</span><span class=\"xml\">!<span class=\"hljs-tag\">&lt;/<span class=\"hljs-name\">p</span>&gt;</span></span>\n</code></pre>\n"
+              "shortText": "",
+              "text": "",
+              "tags": []
             },
             "typeInfo": {
               "isArray": false,
-              "name": "object"
+              "name": "any"
             }
           },
           {
@@ -922,7 +928,7 @@
                 "fileName": "component.ts",
                 "line": 138,
                 "character": 11,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L138"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L138"
               }
             ],
             "comment": {
@@ -955,7 +961,7 @@
                 "fileName": "component.ts",
                 "line": 133,
                 "character": 9,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L133"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L133"
               }
             ],
             "comment": {
@@ -968,7 +974,119 @@
             }
           }
         ],
+        "accessors": [
+          {
+            "name": "args",
+            "slug": "args",
+            "flags": {
+              "isExported": true,
+              "isExternal": true,
+              "isOptional": false,
+              "isPrivate": false,
+              "isPublic": false,
+              "isProtected": false,
+              "isStatic": false
+            },
+            "alias": "args",
+            "fullName": "Component.args",
+            "hierarchy": "Accessor args\n  GetSignature __get:any\n  SetSignature __set:void\n    Parameter args:any",
+            "kindString": "Accessor",
+            "sources": [
+              {
+                "fileName": "component.ts",
+                "line": 165,
+                "character": 10,
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L165"
+              },
+              {
+                "fileName": "component.ts",
+                "line": 169,
+                "character": 10,
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L169"
+              }
+            ],
+            "comment": {
+              "shortText": "<p>Named arguments passed to the component from its parent component.\nThey can be accessed in JavaScript via <code>this.args.argumentName</code> and in the template via <code>@argumentName</code>.</p>\n",
+              "text": "<p>Say you have the following component, which will have two <code>args</code>, <code>firstName</code> and <code>lastName</code>:</p>\n<pre><code class=\"lang-hbs\"><span class=\"xml\"><span class=\"hljs-tag\">&lt;<span class=\"hljs-name\">my-component</span> @<span class=\"hljs-attr\">firstName</span>=<span class=\"hljs-string\">\"Arthur\"</span> @<span class=\"hljs-attr\">lastName</span>=<span class=\"hljs-string\">\"Dent\"</span> /&gt;</span></span>\n</code></pre>\n<p>If you needed to calculate <code>fullName</code> by combining both of them, you would do:</p>\n<pre><code class=\"lang-ts\">didInsertElement() {\n  <span class=\"hljs-built_in\">console</span>.log(<span class=\"hljs-string\">`Hi, my full name is <span class=\"hljs-subst\">${this.args.firstName}</span> <span class=\"hljs-subst\">${this.args.lastName}</span>`</span>);\n}\n</code></pre>\n<p>While in the template you could do:</p>\n<pre><code class=\"lang-hbs\"><span class=\"xml\"><span class=\"hljs-tag\">&lt;<span class=\"hljs-name\">p</span>&gt;</span>Welcome, </span><span class=\"hljs-template-variable\">{{@firstName}}</span><span class=\"xml\"> </span><span class=\"hljs-template-variable\">{{@lastName}}</span><span class=\"xml\">!<span class=\"hljs-tag\">&lt;/<span class=\"hljs-name\">p</span>&gt;</span></span>\n</code></pre>\n"
+            },
+            "getSignatures": [
+              {
+                "name": "__get",
+                "slug": "__get",
+                "flags": {},
+                "alias": "__get",
+                "fullName": "Component.args.__get",
+                "hierarchy": "GetSignature __get:any",
+                "kindString": "Get signature",
+                "sources": [
+                  {
+                    "fileName": "component.ts",
+                    "line": 165,
+                    "character": 10,
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L165"
+                  }
+                ],
+                "comment": {
+                  "shortText": "<p>Named arguments passed to the component from its parent component.\nThey can be accessed in JavaScript via <code>this.args.argumentName</code> and in the template via <code>@argumentName</code>.</p>\n",
+                  "text": "<p>Say you have the following component, which will have two <code>args</code>, <code>firstName</code> and <code>lastName</code>:</p>\n<pre><code class=\"lang-hbs\"><span class=\"xml\"><span class=\"hljs-tag\">&lt;<span class=\"hljs-name\">my-component</span> @<span class=\"hljs-attr\">firstName</span>=<span class=\"hljs-string\">\"Arthur\"</span> @<span class=\"hljs-attr\">lastName</span>=<span class=\"hljs-string\">\"Dent\"</span> /&gt;</span></span>\n</code></pre>\n<p>If you needed to calculate <code>fullName</code> by combining both of them, you would do:</p>\n<pre><code class=\"lang-ts\">didInsertElement() {\n  <span class=\"hljs-built_in\">console</span>.log(<span class=\"hljs-string\">`Hi, my full name is <span class=\"hljs-subst\">${this.args.firstName}</span> <span class=\"hljs-subst\">${this.args.lastName}</span>`</span>);\n}\n</code></pre>\n<p>While in the template you could do:</p>\n<pre><code class=\"lang-hbs\"><span class=\"xml\"><span class=\"hljs-tag\">&lt;<span class=\"hljs-name\">p</span>&gt;</span>Welcome, </span><span class=\"hljs-template-variable\">{{@firstName}}</span><span class=\"xml\"> </span><span class=\"hljs-template-variable\">{{@lastName}}</span><span class=\"xml\">!<span class=\"hljs-tag\">&lt;/<span class=\"hljs-name\">p</span>&gt;</span></span>\n</code></pre>\n"
+                },
+                "typeInfo": {
+                  "isArray": false,
+                  "name": "any"
+                }
+              }
+            ]
+          }
+        ],
         "methods": [
+          {
+            "name": "destroy",
+            "slug": "destroy",
+            "flags": {
+              "isExported": true,
+              "isExternal": true,
+              "isOptional": false,
+              "isPrivate": false,
+              "isPublic": false,
+              "isProtected": false,
+              "isStatic": false
+            },
+            "alias": "destroy",
+            "fullName": "Component.destroy",
+            "hierarchy": "Method destroy\n  CallSignature destroy:void",
+            "kindString": "Method",
+            "sources": [
+              {
+                "fileName": "component.ts",
+                "line": 211,
+                "character": 9,
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L211"
+              }
+            ],
+            "callSignatures": [
+              {
+                "name": "destroy",
+                "slug": "destroy-1",
+                "flags": {},
+                "alias": "destroy-1",
+                "fullName": "Component.destroy.destroy",
+                "hierarchy": "CallSignature destroy:void",
+                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "component.ts",
+                    "line": 211,
+                    "character": 9,
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L211"
+                  }
+                ],
+                "typeInfo": {
+                  "isArray": false,
+                  "name": "void"
+                }
+              }
+            ]
+          },
           {
             "name": "didInsertElement",
             "slug": "didinsertelement",
@@ -988,9 +1106,9 @@
             "sources": [
               {
                 "fileName": "component.ts",
-                "line": 186,
+                "line": 198,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L186"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L198"
               }
             ],
             "callSignatures": [
@@ -1005,9 +1123,9 @@
                 "sources": [
                   {
                     "fileName": "component.ts",
-                    "line": 186,
+                    "line": 198,
                     "character": 18,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L186"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L198"
                   }
                 ],
                 "comment": {
@@ -1040,9 +1158,9 @@
             "sources": [
               {
                 "fileName": "component.ts",
-                "line": 192,
+                "line": 204,
                 "character": 11,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L192"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L204"
               }
             ],
             "callSignatures": [
@@ -1057,9 +1175,9 @@
                 "sources": [
                   {
                     "fileName": "component.ts",
-                    "line": 192,
+                    "line": 204,
                     "character": 11,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L192"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L204"
                   }
                 ],
                 "comment": {
@@ -1092,9 +1210,9 @@
             "sources": [
               {
                 "fileName": "component.ts",
-                "line": 194,
+                "line": 215,
                 "character": 10,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L194"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L215"
               }
             ],
             "callSignatures": [
@@ -1109,14 +1227,66 @@
                 "sources": [
                   {
                     "fileName": "component.ts",
-                    "line": 194,
+                    "line": 215,
                     "character": 10,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L194"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L215"
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "willDestroy",
+            "slug": "willdestroy",
+            "flags": {
+              "isExported": true,
+              "isExternal": true,
+              "isOptional": false,
+              "isPrivate": false,
+              "isPublic": false,
+              "isProtected": false,
+              "isStatic": false
+            },
+            "alias": "willdestroy",
+            "fullName": "Component.willDestroy",
+            "hierarchy": "Method willDestroy\n  CallSignature willDestroy:void",
+            "kindString": "Method",
+            "sources": [
+              {
+                "fileName": "component.ts",
+                "line": 209,
+                "character": 13,
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L209"
+              }
+            ],
+            "callSignatures": [
+              {
+                "name": "willDestroy",
+                "slug": "willdestroy-1",
+                "flags": {},
+                "alias": "willdestroy-1",
+                "fullName": "Component.willDestroy.willDestroy",
+                "hierarchy": "CallSignature willDestroy:void",
+                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "component.ts",
+                    "line": 209,
+                    "character": 13,
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L209"
+                  }
+                ],
+                "comment": {
+                  "shortText": "<p>Called before the component has been removed from the DOM.</p>\n",
+                  "text": "<p>Called before the component has been removed from the DOM.</p>\n"
+                },
+                "typeInfo": {
+                  "isArray": false,
+                  "name": "void"
                 }
               }
             ]
@@ -1140,9 +1310,9 @@
             "sources": [
               {
                 "fileName": "component.ts",
-                "line": 167,
+                "line": 179,
                 "character": 15,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L167"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L179"
               }
             ],
             "callSignatures": [
@@ -1157,16 +1327,16 @@
                 "sources": [
                   {
                     "fileName": "component.ts",
-                    "line": 167,
+                    "line": 179,
                     "character": 15,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L167"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L179"
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "Component",
                   "link": {
-                    "id": "94",
+                    "id": "98",
                     "type": "class",
                     "slug": "component",
                     "sources": [
@@ -1174,7 +1344,7 @@
                         "fileName": "component.ts",
                         "line": 127,
                         "character": 15,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L127"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L127"
                       }
                     ],
                     "parent": {
@@ -1210,7 +1380,7 @@
       }
     },
     {
-      "id": "300",
+      "id": "313",
       "type": "class",
       "attributes": {
         "name": "ComponentDefinition",
@@ -1289,7 +1459,7 @@
                   "isArray": false,
                   "name": "ComponentDefinition",
                   "link": {
-                    "id": "300",
+                    "id": "313",
                     "type": "class",
                     "slug": "componentdefinition",
                     "sources": [
@@ -1340,7 +1510,7 @@
                       "isArray": false,
                       "name": "ComponentManager",
                       "link": {
-                        "id": "246",
+                        "id": "258",
                         "type": "class",
                         "slug": "componentmanager",
                         "sources": [
@@ -1348,7 +1518,7 @@
                             "fileName": "component-manager.ts",
                             "line": 52,
                             "character": 37,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L52"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L52"
                           }
                         ],
                         "parent": {
@@ -1391,15 +1561,15 @@
                       "isArray": false,
                       "name": "ComponentFactory",
                       "link": {
-                        "id": "110",
+                        "id": "122",
                         "type": "interface",
                         "slug": "componentfactory",
                         "sources": [
                           {
                             "fileName": "component.ts",
-                            "line": 201,
+                            "line": 222,
                             "character": 33,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L201"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L222"
                           }
                         ],
                         "parent": {
@@ -1445,7 +1615,7 @@
               "isArray": false,
               "name": "ComponentClass",
               "link": {
-                "id": "316",
+                "id": "329",
                 "type": "property",
                 "slug": "componentclass",
                 "sources": [
@@ -1457,7 +1627,7 @@
                   }
                 ],
                 "parent": {
-                  "id": "300",
+                  "id": "313",
                   "type": "class",
                   "slug": "componentdefinition",
                   "sources": [
@@ -1529,15 +1699,15 @@
               "isArray": false,
               "name": "ComponentFactory",
               "link": {
-                "id": "110",
+                "id": "122",
                 "type": "interface",
                 "slug": "componentfactory",
                 "sources": [
                   {
                     "fileName": "component.ts",
-                    "line": 201,
+                    "line": 222,
                     "character": 33,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L201"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L222"
                   }
                 ],
                 "parent": {
@@ -1683,7 +1853,7 @@
                   "isArray": false,
                   "name": "object",
                   "declaration": {
-                    "id": "312",
+                    "id": "325",
                     "type": "type-literal",
                     "attributes": {
                       "name": "__type",
@@ -1776,7 +1946,7 @@
       }
     },
     {
-      "id": "246",
+      "id": "258",
       "type": "class",
       "attributes": {
         "name": "ComponentManager",
@@ -1793,7 +1963,7 @@
         },
         "alias": "componentmanager",
         "fullName": "ComponentManager",
-        "hierarchy": "Class ComponentManager\n  Constructor constructor\n    ConstructorSignature new ComponentManager:ComponentManager\n      Parameter options:ConstructorOptions\n  Property env:Environment\n  Method create\n    CallSignature create:ComponentStateBucket | null\n      Parameter environment:Environment\n      Parameter definition:ComponentDefinition\n      Parameter volatileArgs:Arguments\n  Method createComponentDefinition\n    CallSignature createComponentDefinition:ComponentDefinition\n      Parameter name:string\n      Parameter template:Template<any>\n      Parameter componentFactory:Factory<Component>\n  Method didCreate\n    CallSignature didCreate:void\n      Parameter bucket:ComponentStateBucket\n  Method didCreateElement\n    CallSignature didCreateElement:void\n      Parameter bucket:ComponentStateBucket\n      Parameter element:Element\n  Method didRenderLayout\n    CallSignature didRenderLayout:void\n      Parameter bucket:ComponentStateBucket\n      Parameter bounds:Bounds\n  Method didUpdate\n    CallSignature didUpdate:void\n      Parameter bucket:ComponentStateBucket\n  Method didUpdateLayout\n    CallSignature didUpdateLayout:void\n  Method getDestructor\n    CallSignature getDestructor:null\n  Method getSelf\n    CallSignature getSelf:RootReference\n      Parameter bucket:ComponentStateBucket\n  Method getTag\n    CallSignature getTag:null\n  Method layoutFor\n    CallSignature layoutFor:CompiledDynamicProgram\n      Parameter definition:ComponentDefinition\n      Parameter bucket:ComponentStateBucket\n      Parameter env:Environment\n  Method prepareArgs\n    CallSignature prepareArgs:null\n      Parameter definition:ComponentDefinition\n      Parameter args:Arguments\n  Method update\n    CallSignature update:void\n      Parameter bucket:ComponentStateBucket\n      Parameter scope:DynamicScope\n  Method create\n    CallSignature create:ComponentManager\n      Parameter options:ConstructorOptions",
+        "hierarchy": "Class ComponentManager\n  Constructor constructor\n    ConstructorSignature new ComponentManager:ComponentManager\n      Parameter options:ConstructorOptions\n  Property env:Environment\n  Method create\n    CallSignature create:ComponentStateBucket | null\n      Parameter environment:Environment\n      Parameter definition:ComponentDefinition\n      Parameter volatileArgs:Arguments\n  Method createComponentDefinition\n    CallSignature createComponentDefinition:ComponentDefinition\n      Parameter name:string\n      Parameter template:Template<any>\n      Parameter componentFactory:Factory<Component>\n  Method didCreate\n    CallSignature didCreate:void\n      Parameter bucket:ComponentStateBucket\n  Method didCreateElement\n    CallSignature didCreateElement:void\n      Parameter bucket:ComponentStateBucket\n      Parameter element:Element\n  Method didRenderLayout\n    CallSignature didRenderLayout:void\n      Parameter bucket:ComponentStateBucket\n      Parameter bounds:Bounds\n  Method didUpdate\n    CallSignature didUpdate:void\n      Parameter bucket:ComponentStateBucket\n  Method didUpdateLayout\n    CallSignature didUpdateLayout:void\n  Method getDestructor\n    CallSignature getDestructor:Destroyable\n      Parameter bucket:ComponentStateBucket\n  Method getSelf\n    CallSignature getSelf:RootReference\n      Parameter bucket:ComponentStateBucket\n  Method getTag\n    CallSignature getTag:null\n  Method layoutFor\n    CallSignature layoutFor:CompiledDynamicProgram\n      Parameter definition:ComponentDefinition\n      Parameter bucket:ComponentStateBucket\n      Parameter env:Environment\n  Method prepareArgs\n    CallSignature prepareArgs:null\n      Parameter definition:ComponentDefinition\n      Parameter args:Arguments\n  Method update\n    CallSignature update:void\n      Parameter bucket:ComponentStateBucket\n      Parameter scope:DynamicScope\n  Method create\n    CallSignature create:ComponentManager\n      Parameter options:ConstructorOptions",
         "kindString": "Class",
         "implementedTypes": [
           {
@@ -1806,7 +1976,7 @@
             "fileName": "component-manager.ts",
             "line": 52,
             "character": 37,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L52"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L52"
           }
         ],
         "constructors": [
@@ -1831,7 +2001,7 @@
                 "fileName": "component-manager.ts",
                 "line": 57,
                 "character": 3,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L57"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L57"
               }
             ],
             "constructorSignatures": [
@@ -1848,14 +2018,14 @@
                     "fileName": "component-manager.ts",
                     "line": 57,
                     "character": 3,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L57"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L57"
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "ComponentManager",
                   "link": {
-                    "id": "246",
+                    "id": "258",
                     "type": "class",
                     "slug": "componentmanager",
                     "sources": [
@@ -1863,7 +2033,7 @@
                         "fileName": "component-manager.ts",
                         "line": 52,
                         "character": 37,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L52"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L52"
                       }
                     ],
                     "parent": {
@@ -1890,7 +2060,7 @@
                       "isArray": false,
                       "name": "ConstructorOptions",
                       "link": {
-                        "id": "233",
+                        "id": "245",
                         "type": "interface",
                         "slug": "constructoroptions",
                         "sources": [
@@ -1898,7 +2068,7 @@
                             "fileName": "component-manager.ts",
                             "line": 23,
                             "character": 35,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L23"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L23"
                           }
                         ],
                         "parent": {
@@ -1937,7 +2107,7 @@
                 "fileName": "component-manager.ts",
                 "line": 53,
                 "character": 13,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L53"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L53"
               }
             ],
             "typeInfo": {
@@ -1968,7 +2138,7 @@
                 "fileName": "component-manager.ts",
                 "line": 67,
                 "character": 8,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L67"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L67"
               }
             ],
             "callSignatures": [
@@ -1985,7 +2155,7 @@
                     "fileName": "component-manager.ts",
                     "line": 67,
                     "character": 8,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L67"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L67"
                   }
                 ],
                 "typeInfo": {
@@ -1996,7 +2166,7 @@
                       "isArray": false,
                       "name": "ComponentStateBucket",
                       "link": {
-                        "id": "235",
+                        "id": "247",
                         "type": "class",
                         "slug": "componentstatebucket",
                         "sources": [
@@ -2004,7 +2174,7 @@
                             "fileName": "component-manager.ts",
                             "line": 27,
                             "character": 33,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L27"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L27"
                           }
                         ],
                         "parent": {
@@ -2053,7 +2223,7 @@
                       "isArray": false,
                       "name": "ComponentDefinition",
                       "link": {
-                        "id": "300",
+                        "id": "313",
                         "type": "class",
                         "slug": "componentdefinition",
                         "sources": [
@@ -2114,7 +2284,7 @@
                 "fileName": "component-manager.ts",
                 "line": 75,
                 "character": 27,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L75"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L75"
               }
             ],
             "callSignatures": [
@@ -2131,14 +2301,14 @@
                     "fileName": "component-manager.ts",
                     "line": 75,
                     "character": 27,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L75"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L75"
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "ComponentDefinition",
                   "link": {
-                    "id": "300",
+                    "id": "313",
                     "type": "class",
                     "slug": "componentdefinition",
                     "sources": [
@@ -2231,7 +2401,7 @@
                 "fileName": "component-manager.ts",
                 "line": 99,
                 "character": 11,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L99"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L99"
               }
             ],
             "callSignatures": [
@@ -2248,7 +2418,7 @@
                     "fileName": "component-manager.ts",
                     "line": 99,
                     "character": 11,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L99"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L99"
                   }
                 ],
                 "typeInfo": {
@@ -2271,7 +2441,7 @@
                       "isArray": false,
                       "name": "ComponentStateBucket",
                       "link": {
-                        "id": "235",
+                        "id": "247",
                         "type": "class",
                         "slug": "componentstatebucket",
                         "sources": [
@@ -2279,7 +2449,7 @@
                             "fileName": "component-manager.ts",
                             "line": 27,
                             "character": 33,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L27"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L27"
                           }
                         ],
                         "parent": {
@@ -2316,7 +2486,7 @@
                 "fileName": "component-manager.ts",
                 "line": 91,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L91"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L91"
               }
             ],
             "callSignatures": [
@@ -2333,7 +2503,7 @@
                     "fileName": "component-manager.ts",
                     "line": 91,
                     "character": 18,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L91"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L91"
                   }
                 ],
                 "typeInfo": {
@@ -2356,7 +2526,7 @@
                       "isArray": false,
                       "name": "ComponentStateBucket",
                       "link": {
-                        "id": "235",
+                        "id": "247",
                         "type": "class",
                         "slug": "componentstatebucket",
                         "sources": [
@@ -2364,7 +2534,7 @@
                             "fileName": "component-manager.ts",
                             "line": 27,
                             "character": 33,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L27"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L27"
                           }
                         ],
                         "parent": {
@@ -2417,7 +2587,7 @@
                 "fileName": "component-manager.ts",
                 "line": 96,
                 "character": 17,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L96"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L96"
               }
             ],
             "callSignatures": [
@@ -2434,7 +2604,7 @@
                     "fileName": "component-manager.ts",
                     "line": 96,
                     "character": 17,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L96"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L96"
                   }
                 ],
                 "typeInfo": {
@@ -2457,7 +2627,7 @@
                       "isArray": false,
                       "name": "ComponentStateBucket",
                       "link": {
-                        "id": "235",
+                        "id": "247",
                         "type": "class",
                         "slug": "componentstatebucket",
                         "sources": [
@@ -2465,7 +2635,7 @@
                             "fileName": "component-manager.ts",
                             "line": 27,
                             "character": 33,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L27"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L27"
                           }
                         ],
                         "parent": {
@@ -2518,7 +2688,7 @@
                 "fileName": "component-manager.ts",
                 "line": 120,
                 "character": 11,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L120"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L120"
               }
             ],
             "callSignatures": [
@@ -2535,7 +2705,7 @@
                     "fileName": "component-manager.ts",
                     "line": 120,
                     "character": 11,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L120"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L120"
                   }
                 ],
                 "typeInfo": {
@@ -2558,7 +2728,7 @@
                       "isArray": false,
                       "name": "ComponentStateBucket",
                       "link": {
-                        "id": "235",
+                        "id": "247",
                         "type": "class",
                         "slug": "componentstatebucket",
                         "sources": [
@@ -2566,7 +2736,7 @@
                             "fileName": "component-manager.ts",
                             "line": 27,
                             "character": 33,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L27"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L27"
                           }
                         ],
                         "parent": {
@@ -2603,7 +2773,7 @@
                 "fileName": "component-manager.ts",
                 "line": 118,
                 "character": 17,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L118"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L118"
               }
             ],
             "callSignatures": [
@@ -2620,7 +2790,7 @@
                     "fileName": "component-manager.ts",
                     "line": 118,
                     "character": 17,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L118"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L118"
                   }
                 ],
                 "typeInfo": {
@@ -2644,14 +2814,14 @@
             },
             "alias": "getdestructor",
             "fullName": "ComponentManager.getDestructor",
-            "hierarchy": "Method getDestructor\n  CallSignature getDestructor:null",
+            "hierarchy": "Method getDestructor\n  CallSignature getDestructor:Destroyable\n    Parameter bucket:ComponentStateBucket",
             "kindString": "Method",
             "sources": [
               {
                 "fileName": "component-manager.ts",
                 "line": 122,
                 "character": 15,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L122"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L122"
               }
             ],
             "callSignatures": [
@@ -2661,20 +2831,57 @@
                 "flags": {},
                 "alias": "getdestructor-1",
                 "fullName": "ComponentManager.getDestructor.getDestructor",
-                "hierarchy": "CallSignature getDestructor:null",
+                "hierarchy": "CallSignature getDestructor:Destroyable\n  Parameter bucket:ComponentStateBucket",
                 "kindString": "Call signature",
                 "sources": [
                   {
                     "fileName": "component-manager.ts",
                     "line": 122,
                     "character": 15,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L122"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L122"
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
-                  "name": "null"
-                }
+                  "name": "Destroyable"
+                },
+                "parameters": [
+                  {
+                    "name": "bucket",
+                    "slug": "bucket-4",
+                    "flags": {
+                      "isOptional": false,
+                      "isRest": false
+                    },
+                    "alias": "bucket-4",
+                    "fullName": "ComponentManager.getDestructor.getDestructor.bucket",
+                    "hierarchy": "Parameter bucket:ComponentStateBucket",
+                    "kindString": "Parameter",
+                    "typeInfo": {
+                      "isArray": false,
+                      "name": "ComponentStateBucket",
+                      "link": {
+                        "id": "247",
+                        "type": "class",
+                        "slug": "componentstatebucket",
+                        "sources": [
+                          {
+                            "fileName": "component-manager.ts",
+                            "line": 27,
+                            "character": 33,
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L27"
+                          }
+                        ],
+                        "parent": {
+                          "id": "0",
+                          "type": "0",
+                          "slug": "_glimmer_component",
+                          "sources": null
+                        }
+                      }
+                    }
+                  }
+                ]
               }
             ]
           },
@@ -2699,7 +2906,7 @@
                 "fileName": "component-manager.ts",
                 "line": 86,
                 "character": 9,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L86"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L86"
               }
             ],
             "callSignatures": [
@@ -2716,14 +2923,14 @@
                     "fileName": "component-manager.ts",
                     "line": 86,
                     "character": 9,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L86"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L86"
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "RootReference",
                   "link": {
-                    "id": "136",
+                    "id": "148",
                     "type": "class",
                     "slug": "rootreference",
                     "sources": [
@@ -2731,7 +2938,7 @@
                         "fileName": "references.ts",
                         "line": 51,
                         "character": 26,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L51"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L51"
                       }
                     ],
                     "parent": {
@@ -2745,12 +2952,12 @@
                 "parameters": [
                   {
                     "name": "bucket",
-                    "slug": "bucket-4",
+                    "slug": "bucket-5",
                     "flags": {
                       "isOptional": false,
                       "isRest": false
                     },
-                    "alias": "bucket-4",
+                    "alias": "bucket-5",
                     "fullName": "ComponentManager.getSelf.getSelf.bucket",
                     "hierarchy": "Parameter bucket:ComponentStateBucket",
                     "kindString": "Parameter",
@@ -2758,7 +2965,7 @@
                       "isArray": false,
                       "name": "ComponentStateBucket",
                       "link": {
-                        "id": "235",
+                        "id": "247",
                         "type": "class",
                         "slug": "componentstatebucket",
                         "sources": [
@@ -2766,7 +2973,7 @@
                             "fileName": "component-manager.ts",
                             "line": 27,
                             "character": 33,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L27"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L27"
                           }
                         ],
                         "parent": {
@@ -2803,7 +3010,7 @@
                 "fileName": "component-manager.ts",
                 "line": 103,
                 "character": 8,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L103"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L103"
               }
             ],
             "callSignatures": [
@@ -2820,7 +3027,7 @@
                     "fileName": "component-manager.ts",
                     "line": 103,
                     "character": 8,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L103"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L103"
                   }
                 ],
                 "typeInfo": {
@@ -2851,7 +3058,7 @@
                 "fileName": "component-manager.ts",
                 "line": 79,
                 "character": 11,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L79"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L79"
               }
             ],
             "callSignatures": [
@@ -2868,7 +3075,7 @@
                     "fileName": "component-manager.ts",
                     "line": 79,
                     "character": 11,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L79"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L79"
                   }
                 ],
                 "typeInfo": {
@@ -2891,7 +3098,7 @@
                       "isArray": false,
                       "name": "ComponentDefinition",
                       "link": {
-                        "id": "300",
+                        "id": "313",
                         "type": "class",
                         "slug": "componentdefinition",
                         "sources": [
@@ -2913,12 +3120,12 @@
                   },
                   {
                     "name": "bucket",
-                    "slug": "bucket-5",
+                    "slug": "bucket-6",
                     "flags": {
                       "isOptional": false,
                       "isRest": false
                     },
-                    "alias": "bucket-5",
+                    "alias": "bucket-6",
                     "fullName": "ComponentManager.layoutFor.layoutFor.bucket",
                     "hierarchy": "Parameter bucket:ComponentStateBucket",
                     "kindString": "Parameter",
@@ -2926,7 +3133,7 @@
                       "isArray": false,
                       "name": "ComponentStateBucket",
                       "link": {
-                        "id": "235",
+                        "id": "247",
                         "type": "class",
                         "slug": "componentstatebucket",
                         "sources": [
@@ -2934,7 +3141,7 @@
                             "fileName": "component-manager.ts",
                             "line": 27,
                             "character": 33,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L27"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L27"
                           }
                         ],
                         "parent": {
@@ -2987,7 +3194,7 @@
                 "fileName": "component-manager.ts",
                 "line": 63,
                 "character": 13,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L63"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L63"
               }
             ],
             "callSignatures": [
@@ -3004,7 +3211,7 @@
                     "fileName": "component-manager.ts",
                     "line": 63,
                     "character": 13,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L63"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L63"
                   }
                 ],
                 "typeInfo": {
@@ -3027,7 +3234,7 @@
                       "isArray": false,
                       "name": "ComponentDefinition",
                       "link": {
-                        "id": "300",
+                        "id": "313",
                         "type": "class",
                         "slug": "componentdefinition",
                         "sources": [
@@ -3088,7 +3295,7 @@
                 "fileName": "component-manager.ts",
                 "line": 107,
                 "character": 8,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L107"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L107"
               }
             ],
             "callSignatures": [
@@ -3105,7 +3312,7 @@
                     "fileName": "component-manager.ts",
                     "line": 107,
                     "character": 8,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L107"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L107"
                   }
                 ],
                 "typeInfo": {
@@ -3115,12 +3322,12 @@
                 "parameters": [
                   {
                     "name": "bucket",
-                    "slug": "bucket-6",
+                    "slug": "bucket-7",
                     "flags": {
                       "isOptional": false,
                       "isRest": false
                     },
-                    "alias": "bucket-6",
+                    "alias": "bucket-7",
                     "fullName": "ComponentManager.update.update.bucket",
                     "hierarchy": "Parameter bucket:ComponentStateBucket",
                     "kindString": "Parameter",
@@ -3128,7 +3335,7 @@
                       "isArray": false,
                       "name": "ComponentStateBucket",
                       "link": {
-                        "id": "235",
+                        "id": "247",
                         "type": "class",
                         "slug": "componentstatebucket",
                         "sources": [
@@ -3136,7 +3343,7 @@
                             "fileName": "component-manager.ts",
                             "line": 27,
                             "character": 33,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L27"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L27"
                           }
                         ],
                         "parent": {
@@ -3189,7 +3396,7 @@
                 "fileName": "component-manager.ts",
                 "line": 55,
                 "character": 15,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L55"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L55"
               }
             ],
             "callSignatures": [
@@ -3206,14 +3413,14 @@
                     "fileName": "component-manager.ts",
                     "line": 55,
                     "character": 15,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L55"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L55"
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "ComponentManager",
                   "link": {
-                    "id": "246",
+                    "id": "258",
                     "type": "class",
                     "slug": "componentmanager",
                     "sources": [
@@ -3221,7 +3428,7 @@
                         "fileName": "component-manager.ts",
                         "line": 52,
                         "character": 37,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L52"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L52"
                       }
                     ],
                     "parent": {
@@ -3248,7 +3455,7 @@
                       "isArray": false,
                       "name": "ConstructorOptions",
                       "link": {
-                        "id": "233",
+                        "id": "245",
                         "type": "interface",
                         "slug": "constructoroptions",
                         "sources": [
@@ -3256,7 +3463,7 @@
                             "fileName": "component-manager.ts",
                             "line": 23,
                             "character": 35,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L23"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L23"
                           }
                         ],
                         "parent": {
@@ -3276,7 +3483,7 @@
       }
     },
     {
-      "id": "114",
+      "id": "126",
       "type": "class",
       "attributes": {
         "name": "ComponentPathReference",
@@ -3306,7 +3513,7 @@
             "fileName": "references.ts",
             "line": 24,
             "character": 44,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L24"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L24"
           }
         ],
         "comment": {
@@ -3346,7 +3553,7 @@
                 "fileName": "references.ts",
                 "line": 26,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L26"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L26"
               }
             ],
             "getSignatures": [
@@ -3363,7 +3570,7 @@
                     "fileName": "references.ts",
                     "line": 26,
                     "character": 18,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L26"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L26"
                   }
                 ],
                 "typeInfo": {
@@ -3396,7 +3603,7 @@
                 "fileName": "references.ts",
                 "line": 28,
                 "character": 5,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L28"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L28"
               }
             ],
             "callSignatures": [
@@ -3413,7 +3620,7 @@
                     "fileName": "references.ts",
                     "line": 28,
                     "character": 5,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L28"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L28"
                   }
                 ],
                 "typeInfo": {
@@ -3462,7 +3669,7 @@
                 "fileName": "references.ts",
                 "line": 25,
                 "character": 16,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L25"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L25"
               }
             ],
             "callSignatures": [
@@ -3479,7 +3686,7 @@
                     "fileName": "references.ts",
                     "line": 25,
                     "character": 16,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L25"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L25"
                   }
                 ],
                 "typeInfo": {
@@ -3493,7 +3700,7 @@
       }
     },
     {
-      "id": "235",
+      "id": "247",
       "type": "class",
       "attributes": {
         "name": "ComponentStateBucket",
@@ -3517,7 +3724,7 @@
             "fileName": "component-manager.ts",
             "line": 27,
             "character": 33,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L27"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L27"
           }
         ],
         "constructors": [
@@ -3542,7 +3749,7 @@
                 "fileName": "component-manager.ts",
                 "line": 30,
                 "character": 34,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L30"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L30"
               }
             ],
             "constructorSignatures": [
@@ -3559,14 +3766,14 @@
                     "fileName": "component-manager.ts",
                     "line": 30,
                     "character": 34,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L30"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L30"
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "ComponentStateBucket",
                   "link": {
-                    "id": "235",
+                    "id": "247",
                     "type": "class",
                     "slug": "componentstatebucket",
                     "sources": [
@@ -3574,7 +3781,7 @@
                         "fileName": "component-manager.ts",
                         "line": 27,
                         "character": 33,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L27"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L27"
                       }
                     ],
                     "parent": {
@@ -3601,7 +3808,7 @@
                       "isArray": false,
                       "name": "ComponentDefinition",
                       "link": {
-                        "id": "300",
+                        "id": "313",
                         "type": "class",
                         "slug": "componentdefinition",
                         "sources": [
@@ -3680,7 +3887,7 @@
                 "fileName": "component-manager.ts",
                 "line": 30,
                 "character": 14,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L30"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L30"
               }
             ],
             "typeInfo": {
@@ -3709,14 +3916,14 @@
                 "fileName": "component-manager.ts",
                 "line": 29,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L29"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L29"
               }
             ],
             "typeInfo": {
               "isArray": false,
               "name": "Component",
               "link": {
-                "id": "94",
+                "id": "98",
                 "type": "class",
                 "slug": "component",
                 "sources": [
@@ -3724,7 +3931,7 @@
                     "fileName": "component.ts",
                     "line": 127,
                     "character": 15,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L127"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L127"
                   }
                 ],
                 "parent": {
@@ -3757,7 +3964,7 @@
                 "fileName": "component-manager.ts",
                 "line": 28,
                 "character": 13,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L28"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L28"
               }
             ],
             "typeInfo": {
@@ -3788,7 +3995,7 @@
                 "fileName": "component-manager.ts",
                 "line": 47,
                 "character": 19,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L47"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L47"
               }
             ],
             "callSignatures": [
@@ -3805,7 +4012,7 @@
                     "fileName": "component-manager.ts",
                     "line": 47,
                     "character": 19,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L47"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L47"
                   }
                 ],
                 "typeInfo": {
@@ -3819,7 +4026,7 @@
       }
     },
     {
-      "id": "216",
+      "id": "228",
       "type": "class",
       "attributes": {
         "name": "ConditionalReference",
@@ -3855,7 +4062,7 @@
             "fileName": "references.ts",
             "line": 165,
             "character": 33,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L165"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L165"
           }
         ],
         "constructors": [
@@ -3904,7 +4111,7 @@
                   "isArray": false,
                   "name": "ConditionalReference",
                   "link": {
-                    "id": "216",
+                    "id": "228",
                     "type": "class",
                     "slug": "conditionalreference",
                     "sources": [
@@ -3912,7 +4119,7 @@
                         "fileName": "references.ts",
                         "line": 165,
                         "character": 33,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L165"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L165"
                       }
                     ],
                     "parent": {
@@ -4112,7 +4319,7 @@
                 "fileName": "references.ts",
                 "line": 166,
                 "character": 15,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L166"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L166"
               }
             ],
             "callSignatures": [
@@ -4129,7 +4336,7 @@
                     "fileName": "references.ts",
                     "line": 166,
                     "character": 15,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L166"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L166"
                   }
                 ],
                 "typeInfo": {
@@ -4144,7 +4351,7 @@
                       "isArray": false,
                       "name": "ConditionalReference",
                       "link": {
-                        "id": "216",
+                        "id": "228",
                         "type": "class",
                         "slug": "conditionalreference",
                         "sources": [
@@ -4152,7 +4359,7 @@
                             "fileName": "references.ts",
                             "line": 165,
                             "character": 33,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L165"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L165"
                           }
                         ],
                         "parent": {
@@ -4212,9 +4419,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 103,
+            "line": 104,
             "character": 25,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L103"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L104"
           }
         ],
         "comment": {
@@ -4241,9 +4448,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 107,
+                "line": 108,
                 "character": 46,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L107"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L108"
               }
             ],
             "constructorSignatures": [
@@ -4258,9 +4465,9 @@
                 "sources": [
                   {
                     "fileName": "tracked.ts",
-                    "line": 107,
+                    "line": 108,
                     "character": 46,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L107"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L108"
                   }
                 ],
                 "typeInfo": {
@@ -4273,9 +4480,9 @@
                     "sources": [
                       {
                         "fileName": "tracked.ts",
-                        "line": 103,
+                        "line": 104,
                         "character": 25,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L103"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L104"
                       }
                     ],
                     "parent": {
@@ -4308,9 +4515,9 @@
                         "sources": [
                           {
                             "fileName": "tracked.ts",
-                            "line": 103,
+                            "line": 104,
                             "character": 25,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L103"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L104"
                           }
                         ],
                         "parent": {
@@ -4347,9 +4554,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 105,
+                "line": 106,
                 "character": 22,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L105"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L106"
               }
             ],
             "typeInfo": {
@@ -4376,9 +4583,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 104,
+                "line": 105,
                 "character": 6,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L104"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L105"
               }
             ],
             "typeInfo": {
@@ -4405,9 +4612,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 106,
+                "line": 107,
                 "character": 19,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L106"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L107"
               }
             ],
             "typeInfo": {
@@ -4434,9 +4641,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 107,
+                "line": 108,
                 "character": 29,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L107"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L108"
               }
             ],
             "typeInfo": {
@@ -4465,9 +4672,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 143,
+                "line": 144,
                 "character": 17,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L143"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L144"
               }
             ],
             "callSignatures": [
@@ -4482,9 +4689,9 @@
                 "sources": [
                   {
                     "fileName": "tracked.ts",
-                    "line": 143,
+                    "line": 144,
                     "character": 17,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L143"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L144"
                   }
                 ],
                 "comment": {
@@ -4511,15 +4718,15 @@
                       "isArray": false,
                       "name": "Key",
                       "link": {
-                        "id": "50",
+                        "id": "54",
                         "type": "type-alias",
                         "slug": "key",
                         "sources": [
                           {
                             "fileName": "tracked.ts",
-                            "line": 52,
+                            "line": 53,
                             "character": 15,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L52"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L53"
                           }
                         ],
                         "parent": {
@@ -4554,9 +4761,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 125,
+                "line": 126,
                 "character": 8,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L125"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L126"
               }
             ],
             "callSignatures": [
@@ -4571,9 +4778,9 @@
                 "sources": [
                   {
                     "fileName": "tracked.ts",
-                    "line": 125,
+                    "line": 126,
                     "character": 8,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L125"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L126"
                   }
                 ],
                 "comment": {
@@ -4600,15 +4807,15 @@
                       "isArray": false,
                       "name": "Key",
                       "link": {
-                        "id": "50",
+                        "id": "54",
                         "type": "type-alias",
                         "slug": "key",
                         "sources": [
                           {
                             "fileName": "tracked.ts",
-                            "line": 52,
+                            "line": 53,
                             "character": 15,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L52"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L53"
                           }
                         ],
                         "parent": {
@@ -4628,7 +4835,7 @@
       }
     },
     {
-      "id": "181",
+      "id": "193",
       "type": "class",
       "attributes": {
         "name": "NestedPropertyReference",
@@ -4658,7 +4865,7 @@
             "isArray": false,
             "name": "PropertyReference",
             "link": {
-              "id": "148",
+              "id": "160",
               "type": "class",
               "slug": "propertyreference",
               "sources": [
@@ -4666,7 +4873,7 @@
                   "fileName": "references.ts",
                   "line": 65,
                   "character": 39,
-                  "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L65"
+                  "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L65"
                 }
               ],
               "parent": {
@@ -4683,7 +4890,7 @@
             "fileName": "references.ts",
             "line": 102,
             "character": 36,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L102"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L102"
           }
         ],
         "constructors": [
@@ -4708,7 +4915,7 @@
                 "fileName": "references.ts",
                 "line": 106,
                 "character": 31,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L106"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L106"
               }
             ],
             "constructorSignatures": [
@@ -4725,14 +4932,14 @@
                     "fileName": "references.ts",
                     "line": 106,
                     "character": 31,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L106"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L106"
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "NestedPropertyReference",
                   "link": {
-                    "id": "181",
+                    "id": "193",
                     "type": "class",
                     "slug": "nestedpropertyreference",
                     "sources": [
@@ -4740,7 +4947,7 @@
                         "fileName": "references.ts",
                         "line": 102,
                         "character": 36,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L102"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L102"
                       }
                     ],
                     "parent": {
@@ -4811,7 +5018,7 @@
                 "fileName": "references.ts",
                 "line": 105,
                 "character": 26,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L105"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L105"
               }
             ],
             "typeInfo": {
@@ -4840,7 +5047,7 @@
                 "fileName": "references.ts",
                 "line": 104,
                 "character": 26,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L104"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L104"
               }
             ],
             "typeInfo": {
@@ -4869,7 +5076,7 @@
                 "fileName": "references.ts",
                 "line": 106,
                 "character": 22,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L106"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L106"
               }
             ],
             "typeInfo": {
@@ -4898,7 +5105,7 @@
                 "fileName": "references.ts",
                 "line": 103,
                 "character": 12,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L103"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L103"
               }
             ],
             "typeInfo": {
@@ -4929,7 +5136,7 @@
                 "fileName": "references.ts",
                 "line": 121,
                 "character": 9,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L121"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L121"
               }
             ],
             "callSignatures": [
@@ -4946,7 +5153,7 @@
                     "fileName": "references.ts",
                     "line": 121,
                     "character": 9,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L121"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L121"
                   }
                 ],
                 "typeInfo": {
@@ -4977,7 +5184,7 @@
                 "fileName": "references.ts",
                 "line": 74,
                 "character": 5,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L74"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L74"
               }
             ],
             "callSignatures": [
@@ -4994,7 +5201,7 @@
                     "fileName": "references.ts",
                     "line": 74,
                     "character": 5,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L74"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L74"
                   }
                 ],
                 "typeInfo": {
@@ -5043,7 +5250,7 @@
                 "fileName": "references.ts",
                 "line": 39,
                 "character": 7,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L39"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L39"
               }
             ],
             "callSignatures": [
@@ -5060,7 +5267,7 @@
                     "fileName": "references.ts",
                     "line": 39,
                     "character": 7,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L39"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L39"
                   }
                 ],
                 "typeInfo": {
@@ -5091,7 +5298,7 @@
                 "fileName": "references.ts",
                 "line": 66,
                 "character": 15,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L66"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L66"
               }
             ],
             "callSignatures": [
@@ -5108,7 +5315,7 @@
                     "fileName": "references.ts",
                     "line": 66,
                     "character": 15,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L66"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L66"
                   }
                 ],
                 "typeInfo": {
@@ -5119,7 +5326,7 @@
                       "isArray": false,
                       "name": "RootPropertyReference",
                       "link": {
-                        "id": "162",
+                        "id": "174",
                         "type": "class",
                         "slug": "rootpropertyreference",
                         "sources": [
@@ -5127,7 +5334,7 @@
                             "fileName": "references.ts",
                             "line": 84,
                             "character": 34,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L84"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L84"
                           }
                         ],
                         "parent": {
@@ -5142,7 +5349,7 @@
                       "isArray": false,
                       "name": "NestedPropertyReference",
                       "link": {
-                        "id": "181",
+                        "id": "193",
                         "type": "class",
                         "slug": "nestedpropertyreference",
                         "sources": [
@@ -5150,7 +5357,7 @@
                             "fileName": "references.ts",
                             "line": 102,
                             "character": 36,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L102"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L102"
                           }
                         ],
                         "parent": {
@@ -5204,7 +5411,7 @@
       }
     },
     {
-      "id": "148",
+      "id": "160",
       "type": "class",
       "attributes": {
         "name": "PropertyReference",
@@ -5234,7 +5441,7 @@
             "isArray": false,
             "name": "CachedReference",
             "link": {
-              "id": "123",
+              "id": "135",
               "type": "class",
               "slug": "cachedreference",
               "sources": [
@@ -5242,7 +5449,7 @@
                   "fileName": "references.ts",
                   "line": 33,
                   "character": 37,
-                  "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L33"
+                  "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L33"
                 }
               ],
               "parent": {
@@ -5259,7 +5466,7 @@
             "fileName": "references.ts",
             "line": 65,
             "character": 39,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L65"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L65"
           }
         ],
         "accessors": [
@@ -5284,7 +5491,7 @@
                 "fileName": "references.ts",
                 "line": 26,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L26"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L26"
               }
             ],
             "getSignatures": [
@@ -5301,7 +5508,7 @@
                     "fileName": "references.ts",
                     "line": 26,
                     "character": 18,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L26"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L26"
                   }
                 ],
                 "typeInfo": {
@@ -5334,7 +5541,7 @@
                 "fileName": "references.ts",
                 "line": 37,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L37"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L37"
               }
             ],
             "callSignatures": [
@@ -5351,7 +5558,7 @@
                     "fileName": "references.ts",
                     "line": 37,
                     "character": 18,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L37"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L37"
                   }
                 ],
                 "typeInfo": {
@@ -5382,7 +5589,7 @@
                 "fileName": "references.ts",
                 "line": 74,
                 "character": 5,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L74"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L74"
               }
             ],
             "callSignatures": [
@@ -5399,7 +5606,7 @@
                     "fileName": "references.ts",
                     "line": 74,
                     "character": 5,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L74"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L74"
                   }
                 ],
                 "typeInfo": {
@@ -5448,7 +5655,7 @@
                 "fileName": "references.ts",
                 "line": 39,
                 "character": 7,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L39"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L39"
               }
             ],
             "callSignatures": [
@@ -5465,7 +5672,7 @@
                     "fileName": "references.ts",
                     "line": 39,
                     "character": 7,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L39"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L39"
                   }
                 ],
                 "typeInfo": {
@@ -5496,7 +5703,7 @@
                 "fileName": "references.ts",
                 "line": 66,
                 "character": 15,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L66"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L66"
               }
             ],
             "callSignatures": [
@@ -5513,7 +5720,7 @@
                     "fileName": "references.ts",
                     "line": 66,
                     "character": 15,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L66"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L66"
                   }
                 ],
                 "typeInfo": {
@@ -5524,7 +5731,7 @@
                       "isArray": false,
                       "name": "RootPropertyReference",
                       "link": {
-                        "id": "162",
+                        "id": "174",
                         "type": "class",
                         "slug": "rootpropertyreference",
                         "sources": [
@@ -5532,7 +5739,7 @@
                             "fileName": "references.ts",
                             "line": 84,
                             "character": 34,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L84"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L84"
                           }
                         ],
                         "parent": {
@@ -5547,7 +5754,7 @@
                       "isArray": false,
                       "name": "NestedPropertyReference",
                       "link": {
-                        "id": "181",
+                        "id": "193",
                         "type": "class",
                         "slug": "nestedpropertyreference",
                         "sources": [
@@ -5555,7 +5762,7 @@
                             "fileName": "references.ts",
                             "line": 102,
                             "character": 36,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L102"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L102"
                           }
                         ],
                         "parent": {
@@ -5609,7 +5816,7 @@
       }
     },
     {
-      "id": "162",
+      "id": "174",
       "type": "class",
       "attributes": {
         "name": "RootPropertyReference",
@@ -5639,7 +5846,7 @@
             "isArray": false,
             "name": "PropertyReference",
             "link": {
-              "id": "148",
+              "id": "160",
               "type": "class",
               "slug": "propertyreference",
               "sources": [
@@ -5647,7 +5854,7 @@
                   "fileName": "references.ts",
                   "line": 65,
                   "character": 39,
-                  "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L65"
+                  "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L65"
                 }
               ],
               "parent": {
@@ -5664,7 +5871,7 @@
             "fileName": "references.ts",
             "line": 84,
             "character": 34,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L84"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L84"
           }
         ],
         "constructors": [
@@ -5689,7 +5896,7 @@
                 "fileName": "references.ts",
                 "line": 87,
                 "character": 31,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L87"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L87"
               }
             ],
             "constructorSignatures": [
@@ -5706,14 +5913,14 @@
                     "fileName": "references.ts",
                     "line": 87,
                     "character": 31,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L87"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L87"
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "RootPropertyReference",
                   "link": {
-                    "id": "162",
+                    "id": "174",
                     "type": "class",
                     "slug": "rootpropertyreference",
                     "sources": [
@@ -5721,7 +5928,7 @@
                         "fileName": "references.ts",
                         "line": 84,
                         "character": 34,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L84"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L84"
                       }
                     ],
                     "parent": {
@@ -5792,7 +5999,7 @@
                 "fileName": "references.ts",
                 "line": 86,
                 "character": 22,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L86"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L86"
               }
             ],
             "typeInfo": {
@@ -5821,7 +6028,7 @@
                 "fileName": "references.ts",
                 "line": 87,
                 "character": 22,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L87"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L87"
               }
             ],
             "typeInfo": {
@@ -5850,7 +6057,7 @@
                 "fileName": "references.ts",
                 "line": 85,
                 "character": 5,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L85"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L85"
               }
             ],
             "typeInfo": {
@@ -5881,7 +6088,7 @@
                 "fileName": "references.ts",
                 "line": 97,
                 "character": 9,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L97"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L97"
               }
             ],
             "callSignatures": [
@@ -5898,7 +6105,7 @@
                     "fileName": "references.ts",
                     "line": 97,
                     "character": 9,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L97"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L97"
                   }
                 ],
                 "typeInfo": {
@@ -5929,7 +6136,7 @@
                 "fileName": "references.ts",
                 "line": 74,
                 "character": 5,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L74"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L74"
               }
             ],
             "callSignatures": [
@@ -5946,7 +6153,7 @@
                     "fileName": "references.ts",
                     "line": 74,
                     "character": 5,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L74"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L74"
                   }
                 ],
                 "typeInfo": {
@@ -5995,7 +6202,7 @@
                 "fileName": "references.ts",
                 "line": 39,
                 "character": 7,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L39"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L39"
               }
             ],
             "callSignatures": [
@@ -6012,7 +6219,7 @@
                     "fileName": "references.ts",
                     "line": 39,
                     "character": 7,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L39"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L39"
                   }
                 ],
                 "typeInfo": {
@@ -6043,7 +6250,7 @@
                 "fileName": "references.ts",
                 "line": 66,
                 "character": 15,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L66"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L66"
               }
             ],
             "callSignatures": [
@@ -6060,7 +6267,7 @@
                     "fileName": "references.ts",
                     "line": 66,
                     "character": 15,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L66"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L66"
                   }
                 ],
                 "typeInfo": {
@@ -6071,7 +6278,7 @@
                       "isArray": false,
                       "name": "RootPropertyReference",
                       "link": {
-                        "id": "162",
+                        "id": "174",
                         "type": "class",
                         "slug": "rootpropertyreference",
                         "sources": [
@@ -6079,7 +6286,7 @@
                             "fileName": "references.ts",
                             "line": 84,
                             "character": 34,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L84"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L84"
                           }
                         ],
                         "parent": {
@@ -6094,7 +6301,7 @@
                       "isArray": false,
                       "name": "NestedPropertyReference",
                       "link": {
-                        "id": "181",
+                        "id": "193",
                         "type": "class",
                         "slug": "nestedpropertyreference",
                         "sources": [
@@ -6102,7 +6309,7 @@
                             "fileName": "references.ts",
                             "line": 102,
                             "character": 36,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L102"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L102"
                           }
                         ],
                         "parent": {
@@ -6156,7 +6363,7 @@
       }
     },
     {
-      "id": "136",
+      "id": "148",
       "type": "class",
       "attributes": {
         "name": "RootReference",
@@ -6192,7 +6399,7 @@
             "fileName": "references.ts",
             "line": 51,
             "character": 26,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L51"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L51"
           }
         ],
         "constructors": [
@@ -6241,7 +6448,7 @@
                   "isArray": false,
                   "name": "RootReference",
                   "link": {
-                    "id": "136",
+                    "id": "148",
                     "type": "class",
                     "slug": "rootreference",
                     "sources": [
@@ -6249,7 +6456,7 @@
                         "fileName": "references.ts",
                         "line": 51,
                         "character": 26,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L51"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L51"
                       }
                     ],
                     "parent": {
@@ -6304,7 +6511,7 @@
                 "fileName": "references.ts",
                 "line": 52,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L52"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L52"
               }
             ],
             "typeInfo": {
@@ -6393,7 +6600,7 @@
                 "fileName": "references.ts",
                 "line": 54,
                 "character": 5,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L54"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L54"
               }
             ],
             "callSignatures": [
@@ -6410,14 +6617,14 @@
                     "fileName": "references.ts",
                     "line": 54,
                     "character": 5,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L54"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L54"
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "RootPropertyReference",
                   "link": {
-                    "id": "162",
+                    "id": "174",
                     "type": "class",
                     "slug": "rootpropertyreference",
                     "sources": [
@@ -6425,7 +6632,7 @@
                         "fileName": "references.ts",
                         "line": 84,
                         "character": 34,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L84"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L84"
                       }
                     ],
                     "parent": {
@@ -6526,7 +6733,7 @@
         },
         "alias": "untrackedpropertyerror",
         "fullName": "UntrackedPropertyError",
-        "hierarchy": "Class UntrackedPropertyError\n  Constructor constructor\n    ConstructorSignature new UntrackedPropertyError:UntrackedPropertyError\n      Parameter target:any\n      Parameter key:string\n      Parameter message:string\n  Property key:string\n  Property target:any\n  Property Error:ErrorConstructor\n  Property message:string\n  Property name:string\n  Property stack:string",
+        "hierarchy": "Class UntrackedPropertyError\n  Constructor constructor\n    ConstructorSignature new UntrackedPropertyError:UntrackedPropertyError\n      Parameter target:any\n      Parameter key:string\n      Parameter message:string\n  Property key:string\n  Property target:any\n  Property Error:ErrorConstructor\n  Property message:string\n  Property name:string\n  Property stack:string\n  Method for\n    CallSignature for:UntrackedPropertyError\n      Parameter obj:any\n      Parameter key:string",
         "kindString": "Class",
         "extendedTypes": [
           {
@@ -6537,9 +6744,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 211,
+            "line": 212,
             "character": 35,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L211"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L212"
           }
         ],
         "constructors": [
@@ -6562,9 +6769,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 211,
-                "character": 51,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L211"
+                "line": 215,
+                "character": 3,
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L215"
               }
             ],
             "constructorSignatures": [
@@ -6579,9 +6786,9 @@
                 "sources": [
                   {
                     "fileName": "tracked.ts",
-                    "line": 211,
-                    "character": 51,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L211"
+                    "line": 215,
+                    "character": 3,
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L215"
                   }
                 ],
                 "typeInfo": {
@@ -6594,9 +6801,9 @@
                     "sources": [
                       {
                         "fileName": "tracked.ts",
-                        "line": 211,
+                        "line": 212,
                         "character": 35,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L211"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L212"
                       }
                     ],
                     "parent": {
@@ -6681,9 +6888,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 212,
+                "line": 217,
                 "character": 44,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L212"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L217"
               }
             ],
             "typeInfo": {
@@ -6710,9 +6917,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 212,
+                "line": 217,
                 "character": 27,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L212"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L217"
               }
             ],
             "typeInfo": {
@@ -6740,7 +6947,8 @@
               {
                 "fileName": "typescript/lib/lib.es6.d.ts",
                 "line": 917,
-                "character": 19
+                "character": 19,
+                "url": null
               }
             ],
             "typeInfo": {
@@ -6768,7 +6976,8 @@
               {
                 "fileName": "typescript/lib/lib.es6.d.ts",
                 "line": 907,
-                "character": 11
+                "character": 11,
+                "url": null
               }
             ],
             "typeInfo": {
@@ -6796,7 +7005,8 @@
               {
                 "fileName": "typescript/lib/lib.es6.d.ts",
                 "line": 906,
-                "character": 8
+                "character": 8,
+                "url": null
               }
             ],
             "typeInfo": {
@@ -6824,7 +7034,8 @@
               {
                 "fileName": "typescript/lib/lib.es6.d.ts",
                 "line": 908,
-                "character": 9
+                "character": 9,
+                "url": null
               }
             ],
             "typeInfo": {
@@ -6832,11 +7043,114 @@
               "name": "string"
             }
           }
+        ],
+        "methods": [
+          {
+            "name": "for",
+            "slug": "for",
+            "flags": {
+              "isExported": true,
+              "isExternal": true,
+              "isOptional": false,
+              "isPrivate": false,
+              "isPublic": false,
+              "isProtected": false,
+              "isStatic": true
+            },
+            "alias": "for",
+            "fullName": "UntrackedPropertyError.for",
+            "hierarchy": "Method for\n  CallSignature for:UntrackedPropertyError\n    Parameter obj:any\n    Parameter key:string",
+            "kindString": "Method",
+            "sources": [
+              {
+                "fileName": "tracked.ts",
+                "line": 213,
+                "character": 12,
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L213"
+              }
+            ],
+            "callSignatures": [
+              {
+                "name": "for",
+                "slug": "for-1",
+                "flags": {},
+                "alias": "for-1",
+                "fullName": "UntrackedPropertyError.for.for",
+                "hierarchy": "CallSignature for:UntrackedPropertyError\n  Parameter obj:any\n  Parameter key:string",
+                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "tracked.ts",
+                    "line": 213,
+                    "character": 12,
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L213"
+                  }
+                ],
+                "typeInfo": {
+                  "isArray": false,
+                  "name": "UntrackedPropertyError",
+                  "link": {
+                    "id": "18",
+                    "type": "class",
+                    "slug": "untrackedpropertyerror",
+                    "sources": [
+                      {
+                        "fileName": "tracked.ts",
+                        "line": 212,
+                        "character": 35,
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L212"
+                      }
+                    ],
+                    "parent": {
+                      "id": "0",
+                      "type": "0",
+                      "slug": "_glimmer_component",
+                      "sources": null
+                    }
+                  }
+                },
+                "parameters": [
+                  {
+                    "name": "obj",
+                    "slug": "obj",
+                    "flags": {
+                      "isOptional": false,
+                      "isRest": false
+                    },
+                    "alias": "obj",
+                    "fullName": "UntrackedPropertyError.for.for.obj",
+                    "hierarchy": "Parameter obj:any",
+                    "kindString": "Parameter",
+                    "typeInfo": {
+                      "isArray": false,
+                      "name": "any"
+                    }
+                  },
+                  {
+                    "name": "key",
+                    "slug": "key-2",
+                    "flags": {
+                      "isOptional": false,
+                      "isRest": false
+                    },
+                    "alias": "key-2",
+                    "fullName": "UntrackedPropertyError.for.for.key",
+                    "hierarchy": "Parameter key:string",
+                    "kindString": "Parameter",
+                    "typeInfo": {
+                      "isArray": false,
+                      "name": "string"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
         ]
       }
     },
     {
-      "id": "201",
+      "id": "213",
       "type": "class",
       "attributes": {
         "name": "UpdatableReference",
@@ -6866,7 +7180,7 @@
             "isArray": false,
             "name": "ComponentPathReference",
             "link": {
-              "id": "114",
+              "id": "126",
               "type": "class",
               "slug": "componentpathreference",
               "sources": [
@@ -6874,7 +7188,7 @@
                   "fileName": "references.ts",
                   "line": 24,
                   "character": 44,
-                  "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L24"
+                  "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L24"
                 }
               ],
               "parent": {
@@ -6891,7 +7205,7 @@
             "fileName": "references.ts",
             "line": 140,
             "character": 31,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L140"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L140"
           }
         ],
         "typeParameters": [
@@ -6927,7 +7241,7 @@
                 "fileName": "references.ts",
                 "line": 142,
                 "character": 20,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L142"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L142"
               }
             ],
             "constructorSignatures": [
@@ -6944,14 +7258,14 @@
                     "fileName": "references.ts",
                     "line": 142,
                     "character": 20,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L142"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L142"
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "UpdatableReference",
                   "link": {
-                    "id": "201",
+                    "id": "213",
                     "type": "class",
                     "slug": "updatablereference",
                     "sources": [
@@ -6959,7 +7273,7 @@
                         "fileName": "references.ts",
                         "line": 140,
                         "character": 31,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L140"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L140"
                       }
                     ],
                     "parent": {
@@ -7014,7 +7328,7 @@
                 "fileName": "references.ts",
                 "line": 142,
                 "character": 16,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L142"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L142"
               }
             ],
             "typeInfo": {
@@ -7043,7 +7357,7 @@
                 "fileName": "references.ts",
                 "line": 141,
                 "character": 12,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L141"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L141"
               }
             ],
             "typeInfo": {
@@ -7074,7 +7388,7 @@
                 "fileName": "references.ts",
                 "line": 28,
                 "character": 5,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L28"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L28"
               }
             ],
             "callSignatures": [
@@ -7091,7 +7405,7 @@
                     "fileName": "references.ts",
                     "line": 28,
                     "character": 5,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L28"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L28"
                   }
                 ],
                 "typeInfo": {
@@ -7140,7 +7454,7 @@
                 "fileName": "references.ts",
                 "line": 155,
                 "character": 8,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L155"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L155"
               }
             ],
             "callSignatures": [
@@ -7157,7 +7471,7 @@
                     "fileName": "references.ts",
                     "line": 155,
                     "character": 8,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L155"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L155"
                   }
                 ],
                 "typeInfo": {
@@ -7206,7 +7520,7 @@
                 "fileName": "references.ts",
                 "line": 151,
                 "character": 7,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L151"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L151"
               }
             ],
             "callSignatures": [
@@ -7223,7 +7537,7 @@
                     "fileName": "references.ts",
                     "line": 151,
                     "character": 7,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L151"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L151"
                   }
                 ],
                 "typeInfo": {
@@ -7237,7 +7551,7 @@
       }
     },
     {
-      "id": "110",
+      "id": "122",
       "type": "interface",
       "attributes": {
         "name": "ComponentFactory",
@@ -7259,9 +7573,9 @@
         "sources": [
           {
             "fileName": "component.ts",
-            "line": 201,
+            "line": 222,
             "character": 33,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L201"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L222"
           }
         ],
         "methods": [
@@ -7284,9 +7598,9 @@
             "sources": [
               {
                 "fileName": "component.ts",
-                "line": 202,
+                "line": 223,
                 "character": 8,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L202"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L223"
               }
             ],
             "callSignatures": [
@@ -7301,16 +7615,16 @@
                 "sources": [
                   {
                     "fileName": "component.ts",
-                    "line": 202,
+                    "line": 223,
                     "character": 8,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L202"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L223"
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "Component",
                   "link": {
-                    "id": "94",
+                    "id": "98",
                     "type": "class",
                     "slug": "component",
                     "sources": [
@@ -7318,7 +7632,7 @@
                         "fileName": "component.ts",
                         "line": 127,
                         "character": 15,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component.ts#L127"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component.ts#L127"
                       }
                     ],
                     "parent": {
@@ -7354,7 +7668,7 @@
       }
     },
     {
-      "id": "233",
+      "id": "245",
       "type": "interface",
       "attributes": {
         "name": "ConstructorOptions",
@@ -7378,7 +7692,7 @@
             "fileName": "component-manager.ts",
             "line": 23,
             "character": 35,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L23"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L23"
           }
         ],
         "properties": [
@@ -7403,7 +7717,7 @@
                 "fileName": "component-manager.ts",
                 "line": 24,
                 "character": 5,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/component-manager.ts#L24"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/component-manager.ts#L24"
               }
             ],
             "typeInfo": {
@@ -7437,9 +7751,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 176,
+            "line": 177,
             "character": 29,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L176"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L177"
           }
         ],
         "indexSignatures": [
@@ -7454,9 +7768,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 176,
+                "line": 177,
                 "character": 31,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L176"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L177"
               }
             ],
             "typeInfo": {
@@ -7486,7 +7800,7 @@
       }
     },
     {
-      "id": "30",
+      "id": "34",
       "type": "interface",
       "attributes": {
         "name": "UntrackedPropertyErrorThrower",
@@ -7508,9 +7822,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 221,
+            "line": 226,
             "character": 46,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L221"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L226"
           }
         ],
         "comment": {
@@ -7529,9 +7843,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 221,
+                "line": 226,
                 "character": 48,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L221"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L226"
               }
             ],
             "comment": {
@@ -7581,7 +7895,7 @@
       }
     },
     {
-      "id": "229",
+      "id": "241",
       "type": "function",
       "attributes": {
         "name": "buildError",
@@ -7605,7 +7919,7 @@
             "fileName": "references.ts",
             "line": 79,
             "character": 19,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L79"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L79"
           }
         ],
         "callSignatures": [
@@ -7622,7 +7936,7 @@
                 "fileName": "references.ts",
                 "line": 79,
                 "character": 19,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/references.ts#L79"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/references.ts#L79"
               }
             ],
             "typeInfo": {
@@ -7668,7 +7982,7 @@
       }
     },
     {
-      "id": "55",
+      "id": "59",
       "type": "function",
       "attributes": {
         "name": "combinatorForComputedProperties",
@@ -7690,9 +8004,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 161,
+            "line": 162,
             "character": 40,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L161"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L162"
           }
         ],
         "callSignatures": [
@@ -7707,9 +8021,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 161,
+                "line": 162,
                 "character": 40,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L161"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L162"
               }
             ],
             "typeInfo": {
@@ -7738,9 +8052,9 @@
                     "sources": [
                       {
                         "fileName": "tracked.ts",
-                        "line": 103,
+                        "line": 104,
                         "character": 25,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L103"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L104"
                       }
                     ],
                     "parent": {
@@ -7767,15 +8081,15 @@
                   "isArray": false,
                   "name": "Key",
                   "link": {
-                    "id": "50",
+                    "id": "54",
                     "type": "type-alias",
                     "slug": "key",
                     "sources": [
                       {
                         "fileName": "tracked.ts",
-                        "line": 52,
+                        "line": 53,
                         "character": 15,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L52"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L53"
                       }
                     ],
                     "parent": {
@@ -7806,15 +8120,15 @@
                       "isArray": true,
                       "name": "Key",
                       "link": {
-                        "id": "50",
+                        "id": "54",
                         "type": "type-alias",
                         "slug": "key",
                         "sources": [
                           {
                             "fileName": "tracked.ts",
-                            "line": 52,
+                            "line": 53,
                             "character": 15,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L52"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L53"
                           }
                         ],
                         "parent": {
@@ -7838,7 +8152,7 @@
       }
     },
     {
-      "id": "80",
+      "id": "84",
       "type": "function",
       "attributes": {
         "name": "defaultErrorThrower",
@@ -7860,9 +8174,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 225,
+            "line": 230,
             "character": 28,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L225"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L230"
           }
         ],
         "callSignatures": [
@@ -7877,9 +8191,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 225,
+                "line": 230,
                 "character": 28,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L225"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L230"
               }
             ],
             "typeInfo": {
@@ -7892,9 +8206,9 @@
                 "sources": [
                   {
                     "fileName": "tracked.ts",
-                    "line": 211,
+                    "line": 212,
                     "character": 35,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L211"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L212"
                   }
                 ],
                 "parent": {
@@ -7944,7 +8258,7 @@
       }
     },
     {
-      "id": "44",
+      "id": "48",
       "type": "function",
       "attributes": {
         "name": "descriptorForTrackedComputedProperty",
@@ -7966,9 +8280,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 35,
+            "line": 36,
             "character": 45,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L35"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L36"
           }
         ],
         "callSignatures": [
@@ -7983,9 +8297,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 35,
+                "line": 36,
                 "character": 45,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L35"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L36"
               }
             ],
             "typeInfo": {
@@ -8063,7 +8377,7 @@
       }
     },
     {
-      "id": "65",
+      "id": "69",
       "type": "function",
       "attributes": {
         "name": "hasOwnProperty",
@@ -8085,9 +8399,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 192,
+            "line": 193,
             "character": 23,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L192"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L193"
           }
         ],
         "callSignatures": [
@@ -8102,9 +8416,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 192,
+                "line": 193,
                 "character": 23,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L192"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L193"
               }
             ],
             "typeInfo": {
@@ -8150,7 +8464,7 @@
       }
     },
     {
-      "id": "76",
+      "id": "80",
       "type": "function",
       "attributes": {
         "name": "hasTag",
@@ -8172,9 +8486,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 202,
+            "line": 203,
             "character": 22,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L202"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L203"
           }
         ],
         "callSignatures": [
@@ -8189,9 +8503,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 202,
+                "line": 203,
                 "character": 22,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L202"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L203"
               }
             ],
             "typeInfo": {
@@ -8237,7 +8551,7 @@
       }
     },
     {
-      "id": "89",
+      "id": "93",
       "type": "function",
       "attributes": {
         "name": "installDevModeErrorInterceptor",
@@ -8259,9 +8573,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 247,
+            "line": 252,
             "character": 39,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L247"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L252"
           }
         ],
         "callSignatures": [
@@ -8276,9 +8590,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 247,
+                "line": 252,
                 "character": 39,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L247"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L252"
               }
             ],
             "comment": {
@@ -8337,15 +8651,15 @@
                   "isArray": false,
                   "name": "UntrackedPropertyErrorThrower",
                   "link": {
-                    "id": "30",
+                    "id": "34",
                     "type": "interface",
                     "slug": "untrackedpropertyerrorthrower",
                     "sources": [
                       {
                         "fileName": "tracked.ts",
-                        "line": 221,
+                        "line": 226,
                         "character": 46,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L221"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L226"
                       }
                     ],
                     "parent": {
@@ -8363,7 +8677,7 @@
       }
     },
     {
-      "id": "51",
+      "id": "55",
       "type": "function",
       "attributes": {
         "name": "installTrackedProperty",
@@ -8385,9 +8699,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 63,
+            "line": 64,
             "character": 31,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L63"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L64"
           }
         ],
         "callSignatures": [
@@ -8402,9 +8716,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 63,
+                "line": 64,
                 "character": 31,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L63"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L64"
               }
             ],
             "comment": {
@@ -8447,15 +8761,15 @@
                   "isArray": false,
                   "name": "Key",
                   "link": {
-                    "id": "50",
+                    "id": "54",
                     "type": "type-alias",
                     "slug": "key",
                     "sources": [
                       {
                         "fileName": "tracked.ts",
-                        "line": 52,
+                        "line": 53,
                         "character": 15,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L52"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L53"
                       }
                     ],
                     "parent": {
@@ -8473,7 +8787,7 @@
       }
     },
     {
-      "id": "61",
+      "id": "65",
       "type": "function",
       "attributes": {
         "name": "metaFor",
@@ -8495,9 +8809,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 182,
+            "line": 183,
             "character": 23,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L182"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L183"
           }
         ],
         "callSignatures": [
@@ -8512,9 +8826,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 182,
+                "line": 183,
                 "character": 23,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L182"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L183"
               }
             ],
             "typeInfo": {
@@ -8527,9 +8841,9 @@
                 "sources": [
                   {
                     "fileName": "tracked.ts",
-                    "line": 103,
+                    "line": 104,
                     "character": 25,
-                    "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L103"
+                    "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L104"
                   }
                 ],
                 "parent": {
@@ -8563,7 +8877,7 @@
       }
     },
     {
-      "id": "69",
+      "id": "73",
       "type": "function",
       "attributes": {
         "name": "propertyDidChange",
@@ -8585,9 +8899,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 196,
+            "line": 197,
             "character": 21,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L196"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L197"
           }
         ],
         "callSignatures": [
@@ -8602,9 +8916,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 196,
+                "line": 197,
                 "character": 23,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L196"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L197"
               }
             ],
             "typeInfo": {
@@ -8616,7 +8930,7 @@
       }
     },
     {
-      "id": "71",
+      "id": "75",
       "type": "function",
       "attributes": {
         "name": "setPropertyDidChange",
@@ -8638,9 +8952,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 198,
+            "line": 199,
             "character": 36,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L198"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L199"
           }
         ],
         "callSignatures": [
@@ -8655,9 +8969,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 198,
+                "line": 199,
                 "character": 36,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L198"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L199"
               }
             ],
             "typeInfo": {
@@ -8680,7 +8994,7 @@
                   "isArray": false,
                   "name": "function",
                   "declaration": {
-                    "id": "74",
+                    "id": "78",
                     "type": "type-literal",
                     "attributes": {
                       "name": "__type",
@@ -8693,9 +9007,9 @@
                       "sources": [
                         {
                           "fileName": "tracked.ts",
-                          "line": 198,
+                          "line": 199,
                           "character": 40,
-                          "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L198"
+                          "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L199"
                         }
                       ],
                       "callSignatures": [
@@ -8710,9 +9024,9 @@
                           "sources": [
                             {
                               "fileName": "tracked.ts",
-                              "line": 198,
+                              "line": 199,
                               "character": 40,
-                              "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L198"
+                              "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L199"
                             }
                           ],
                           "typeInfo": {
@@ -8736,9 +9050,9 @@
                     "sources": [
                       {
                         "fileName": "tracked.ts",
-                        "line": 198,
+                        "line": 199,
                         "character": 40,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L198"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L199"
                       }
                     ],
                     "callSignatures": [
@@ -8753,9 +9067,9 @@
                         "sources": [
                           {
                             "fileName": "tracked.ts",
-                            "line": 198,
+                            "line": 199,
                             "character": 40,
-                            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L198"
+                            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L199"
                           }
                         ],
                         "typeInfo": {
@@ -8773,7 +9087,7 @@
       }
     },
     {
-      "id": "84",
+      "id": "88",
       "type": "function",
       "attributes": {
         "name": "tagForProperty",
@@ -8795,9 +9109,9 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 229,
+            "line": 234,
             "character": 30,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L229"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L234"
           }
         ],
         "callSignatures": [
@@ -8812,9 +9126,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 229,
+                "line": 234,
                 "character": 30,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L229"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L234"
               }
             ],
             "typeInfo": {
@@ -8869,15 +9183,15 @@
                   "isArray": false,
                   "name": "UntrackedPropertyErrorThrower",
                   "link": {
-                    "id": "30",
+                    "id": "34",
                     "type": "interface",
                     "slug": "untrackedpropertyerrorthrower",
                     "sources": [
                       {
                         "fileName": "tracked.ts",
-                        "line": 221,
+                        "line": 226,
                         "character": 46,
-                        "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L221"
+                        "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L226"
                       }
                     ],
                     "parent": {
@@ -8895,7 +9209,7 @@
       }
     },
     {
-      "id": "34",
+      "id": "38",
       "type": "function",
       "attributes": {
         "name": "tracked",
@@ -8917,27 +9231,27 @@
         "sources": [
           {
             "fileName": "tracked.ts",
-            "line": 16,
-            "character": 23,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L16"
-          },
-          {
-            "fileName": "tracked.ts",
             "line": 17,
             "character": 23,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L17"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L17"
           },
           {
             "fileName": "tracked.ts",
             "line": 18,
             "character": 23,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L18"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L18"
           },
           {
             "fileName": "tracked.ts",
             "line": 19,
             "character": 23,
-            "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L19"
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L19"
+          },
+          {
+            "fileName": "tracked.ts",
+            "line": 20,
+            "character": 23,
+            "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L20"
           }
         ],
         "callSignatures": [
@@ -8952,9 +9266,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 16,
+                "line": 17,
                 "character": 23,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L16"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L17"
               }
             ],
             "comment": {
@@ -9006,9 +9320,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 17,
+                "line": 18,
                 "character": 23,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L17"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L18"
               }
             ],
             "typeInfo": {
@@ -9061,9 +9375,9 @@
             "sources": [
               {
                 "fileName": "tracked.ts",
-                "line": 18,
+                "line": 19,
                 "character": 23,
-                "url": "https://github.com/glimmerjs/glimmer-component/blob/cef9070/src/tracked.ts#L18"
+                "url": "https://github.com/glimmerjs/glimmer-component/blob/d1619f2/src/tracked.ts#L19"
               }
             ],
             "typeInfo": {
@@ -9135,7 +9449,7 @@
         },
         "alias": "_glimmer_application",
         "fullName": "@glimmer/application",
-        "hierarchy": "Global @glimmer/application\n  Class Application\n    Constructor constructor\n      ConstructorSignature new Application:Application\n        Parameter options:ApplicationOptions\n    Property _container:Container\n    Property _initialized:boolean\n    Property _initializers:Initializer[]\n    Property _registry:Registry\n    Property _renderResult:RenderResult\n    Property _rendered:boolean\n    Property _roots:AppRoot[]\n    Property _rootsIndex:number\n    Property _scheduled:boolean\n    Property env:Environment\n    Property resolver:Resolver\n    Property rootName:string\n    Method renderComponent\n      CallSignature renderComponent:void\n        Parameter component:string | ComponentDefinition<Component>\n        Parameter parent:Node\n        Parameter nextSibling:Option<Node>\n  Class ApplicationRegistry\n    Constructor constructor\n      ConstructorSignature new ApplicationRegistry:ApplicationRegistry\n        Parameter registry:Registry\n        Parameter resolver:Resolver\n    Property _registry:Registry\n    Property _resolver:Resolver\n    Method _toAbsoluteOrTypeSpecifier\n      CallSignature _toAbsoluteOrTypeSpecifier:string\n        Parameter specifier:string\n    Method _toAbsoluteSpecifier\n      CallSignature _toAbsoluteSpecifier:string\n        Parameter specifier:string\n        Parameter referrer:string\n    Method register\n      CallSignature register:void\n        Parameter specifier:string\n        Parameter factory:any\n        Parameter options:RegistrationOptions\n    Method registerInjection\n      CallSignature registerInjection:void\n        Parameter specifier:string\n        Parameter property:string\n        Parameter injection:string\n    Method registerOption\n      CallSignature registerOption:void\n        Parameter specifier:string\n        Parameter option:string\n        Parameter value:any\n    Method registeredInjections\n      CallSignature registeredInjections:Injection[]\n        Parameter specifier:string\n    Method registeredOption\n      CallSignature registeredOption:any\n        Parameter specifier:string\n        Parameter option:string\n    Method registeredOptions\n      CallSignature registeredOptions:any\n        Parameter specifier:string\n    Method registration\n      CallSignature registration:any\n        Parameter specifier:string\n    Method unregister\n      CallSignature unregister:void\n        Parameter specifier:string\n    Method unregisterOption\n      CallSignature unregisterOption:void\n        Parameter specifier:string\n        Parameter option:string\n  Class ArrayIterator\n    Constructor constructor\n      ConstructorSignature new ArrayIterator:ArrayIterator\n        Parameter array:Opaque[]\n        Parameter keyFor:KeyFor<number>\n    Property array:Opaque[]\n    Property keyFor:KeyFor<number>\n    Property position:number\n    Method isEmpty\n      CallSignature isEmpty:boolean\n    Method next\n      CallSignature next:IterationItem<Opaque, number>\n  Class DefaultComponentDefinition\n    Constructor constructor\n      ConstructorSignature new DefaultComponentDefinition:DefaultComponentDefinition\n        Parameter name:string\n        Parameter manager:ComponentManager<any>\n        Parameter ComponentClass:ComponentClass\n    Property ComponentClass:ComponentClass\n    Property manager:ComponentManager<any>\n    Property name:string\n    Method toJSON\n      CallSignature toJSON:string\n  Class DynamicComponentReference\n    Constructor constructor\n      ConstructorSignature new DynamicComponentReference:DynamicComponentReference\n        Parameter nameRef:PathReference<Opaque>\n        Parameter env:GlimmerEnvironment\n        Parameter meta:TemplateMeta\n    Property env:GlimmerEnvironment\n    Property meta:TemplateMeta\n    Property nameRef:PathReference<Opaque>\n    Property tag:TagWrapper<RevisionTag>\n    Method get\n      CallSignature get:PrimitiveReference<undefined>\n    Method value\n      CallSignature value:ComponentDefinition<Opaque>\n  Class DynamicScope\n    Constructor constructor\n      ConstructorSignature new DynamicScope:DynamicScope\n        Parameter bucket:any\n    Property bucket:any\n    Method child\n      CallSignature child:DynamicScope\n    Method get\n      CallSignature get:PathReference<Opaque>\n        Parameter key:string\n    Method set\n      CallSignature set:VersionedPathReference<void | __type>\n        Parameter key:string\n        Parameter reference:PathReference<Opaque>\n  Class EmptyIterator\n    Method isEmpty\n      CallSignature isEmpty:boolean\n    Method next\n      CallSignature next:IterationItem<Opaque, Opaque>\n  Class Environment\n    Constructor constructor\n      ConstructorSignature new Environment:Environment\n        Parameter options:EnvironmentOptions\n    Property appendOperations:DOMTreeConstruction\n    Property components:Dict<ComponentDefinition<void | __type>>\n    Property constants:Constants\n    Property helpers:Dict<Helper>\n    Property managers:Dict<ComponentManager<void | __type>>\n    Property modifiers:Dict<ModifierManager<void | __type>>\n    Property program:Program\n    Property updateOperations:DOMChanges\n    Property uselessAnchor:HTMLAnchorElement\n    Method attributeFor\n      CallSignature attributeFor:AttributeManager\n        Parameter element:Element\n        Parameter attr:string\n        Parameter isTrusting:boolean\n        Parameter namespace:string\n    Method begin\n      CallSignature begin:void\n    Method commit\n      CallSignature commit:void\n    Method didCreate\n      CallSignature didCreate<T>:void\n        TypeParameter T\n        Parameter component:T\n        Parameter manager:ComponentManager<T>\n    Method didDestroy\n      CallSignature didDestroy:void\n        Parameter d:Destroyable\n    Method didUpdate\n      CallSignature didUpdate<T>:void\n        TypeParameter T\n        Parameter component:T\n        Parameter manager:ComponentManager<T>\n    Method getAppendOperations\n      CallSignature getAppendOperations:DOMTreeConstruction\n    Method getComponentDefinition\n      CallSignature getComponentDefinition:ComponentDefinition<Component>\n        Parameter name:string\n        Parameter meta:TemplateMeta\n    Method getDOM\n      CallSignature getDOM:DOMChanges\n    Method getIdentity\n      CallSignature getIdentity:string\n        Parameter object:HasGuid\n    Method hasComponentDefinition\n      CallSignature hasComponentDefinition:boolean\n        Parameter name:string\n        Parameter meta:TemplateMeta\n    Method hasHelper\n      CallSignature hasHelper:boolean\n        Parameter name:string\n        Parameter meta:TemplateMeta\n    Method hasModifier\n      CallSignature hasModifier:boolean\n        Parameter modifierName:string\n        Parameter blockMeta:TemplateMeta\n    Method hasPartial\n      CallSignature hasPartial:boolean\n    Method iterableFor\n      CallSignature iterableFor:OpaqueIterable\n        Parameter ref:Reference<Opaque>\n        Parameter keyPath:string\n    Method lookupHelper\n      CallSignature lookupHelper:GlimmerHelper\n        Parameter name:string\n        Parameter meta:TemplateMeta\n    Method lookupModifier\n      CallSignature lookupModifier:ModifierManager<Opaque>\n        Parameter modifierName:string\n        Parameter blockMeta:TemplateMeta\n    Method lookupPartial\n      CallSignature lookupPartial:any\n    Method macros\n      CallSignature macros:object\n        TypeLiteral __type\n          Variable blocks:BlockMacros\n          Variable inlines:InlineMacros\n    Method managerFor\n      CallSignature managerFor:ComponentManager<Component>\n        Parameter managerId:string\n    Method populateBuiltins\n      CallSignature populateBuiltins:object\n        TypeLiteral __type\n          Variable blocks:Blocks\n          Variable inlines:Inlines\n    Method protocolForURL\n      CallSignature protocolForURL:string\n        Parameter url:string\n    Method registerComponent\n      CallSignature registerComponent:ComponentDefinition<Component>\n        Parameter name:string\n        Parameter templateSpecifier:string\n        Parameter meta:TemplateMeta\n        Parameter owner:Owner\n    Method registerHelper\n      CallSignature registerHelper:GlimmerHelper\n        Parameter specifier:string\n        Parameter owner:Owner\n    Method scheduleInstallModifier\n      CallSignature scheduleInstallModifier<T>:void\n        TypeParameter T\n        Parameter modifier:T\n        Parameter manager:ModifierManager<T>\n    Method scheduleUpdateModifier\n      CallSignature scheduleUpdateModifier<T>:void\n        TypeParameter T\n        Parameter modifier:T\n        Parameter manager:ModifierManager<T>\n    Method toConditionalReference\n      CallSignature toConditionalReference:Reference<boolean>\n        Parameter reference:Reference<Opaque>\n    Method create\n      CallSignature create:Environment\n        Parameter options:EnvironmentOptions\n  Class HelperReference\n    Constructor constructor\n      ConstructorSignature new HelperReference:HelperReference\n        Parameter helper:UserHelper\n        Parameter args:Arguments\n    Property args:CapturedArguments\n    Property helper:UserHelper\n    Property tag:TagWrapper<any>\n    Method get\n      CallSignature get:SimplePathReference<Opaque>\n        Parameter prop:string\n    Method value\n      CallSignature value:any\n  Class Iterable\n    Constructor constructor\n      ConstructorSignature new Iterable:Iterable\n        Parameter ref:Reference<Opaque>\n        Parameter keyFor:KeyFor<Opaque>\n    Property keyFor:KeyFor<Opaque>\n    Property ref:Reference<Opaque>\n    Property tag:Tag\n    Method iterate\n      CallSignature iterate:OpaqueIterator\n    Method memoReferenceFor\n      CallSignature memoReferenceFor:UpdatableReference<Opaque>\n        Parameter item:IterationItem<Opaque, Opaque>\n    Method updateMemoReference\n      CallSignature updateMemoReference:void\n        Parameter reference:UpdatableReference<Opaque>\n        Parameter item:IterationItem<Opaque, Opaque>\n    Method updateValueReference\n      CallSignature updateValueReference:void\n        Parameter reference:UpdatableReference<Opaque>\n        Parameter item:IterationItem<Opaque, Opaque>\n    Method valueReferenceFor\n      CallSignature valueReferenceFor:UpdatableReference<Opaque>\n        Parameter item:IterationItem<Opaque, Opaque>\n  Class ObjectKeysIterator\n    Constructor constructor\n      ConstructorSignature new ObjectKeysIterator:ObjectKeysIterator\n        Parameter keys:string[]\n        Parameter values:Opaque[]\n        Parameter keyFor:KeyFor<string>\n    Property keyFor:KeyFor<string>\n    Property keys:string[]\n    Property position:number\n    Property values:Opaque[]\n    Method isEmpty\n      CallSignature isEmpty:boolean\n    Method next\n      CallSignature next:IterationItem<Opaque, string>\n  Class SimplePathReference<T>\n    TypeParameter T\n    Constructor constructor\n      ConstructorSignature new SimplePathReference:SimplePathReference\n        Parameter parent:Reference<T>\n        Parameter property:string\n    Property parent:Reference<T>\n    Property property:string\n    Property tag:TagWrapper<any>\n    Method get\n      CallSignature get:PathReference<Opaque>\n        Parameter prop:string\n    Method value\n      CallSignature value:T\n  Interface AppRoot\n    Property component:string | ComponentDefinition<Component>\n    Property id:number\n    Property nextSibling:Option<Node>\n    Property parent:Node\n  Interface ApplicationOptions\n    Property resolver:Resolver\n    Property rootName:string\n  Interface ComponentDefinitionCreator\n    Method createComponentDefinition\n      CallSignature createComponentDefinition:ComponentDefinition<Component>\n        Parameter name:string\n        Parameter template:Template<TemplateMeta>\n        Parameter componentFactory:Factory<Component>\n  Interface EnvironmentOptions\n    Property appendOperations:DOMTreeConstruction\n    Property document:HTMLDocument\n  Interface ExtendedTemplateMeta\n    Property <template-meta>:true\n    Property managerId:string\n    Property moduleName:string\n    Property specifier:string\n  Interface Initializer\n    Property name:string\n    Method initialize\n      CallSignature initialize:void\n        Parameter registry:RegistryWriter\n  TypeAlias KeyFor:function\n    TypeLiteral __type\n      CallSignature __call:string\n        Parameter item:Opaque\n        Parameter index:T\n  TypeAlias UserHelper:function\n    TypeLiteral __type\n      CallSignature __call:any\n        Parameter args:ReadonlyArray<Opaque>\n        Parameter named:Dict<Opaque>\n  Variable DEFAULT_MANAGER:\"main\"\n  Variable EMPTY_ITERATOR:EmptyIterator\n  Function blockComponentMacro\n    CallSignature blockComponentMacro:boolean\n      Parameter params:any\n      Parameter hash:any\n      Parameter template:any\n      Parameter inverse:any\n      Parameter builder:any\n  Function buildAction\n    CallSignature buildAction:ConstReference<action>\n      Parameter vm:VM\n      Parameter _args:Arguments\n  Function buildUserHelper\n    CallSignature buildUserHelper:GlimmerHelper\n      Parameter helperFunc:any\n  Function canCreateComponentDefinition\n    CallSignature canCreateComponentDefinition:boolean\n      Parameter manager:ComponentDefinitionCreator | ComponentManager<Component>\n  Function debugInfoForReference\n    CallSignature debugInfoForReference:string\n      Parameter reference:any\n  Function debugName\n    CallSignature debugName:any\n      Parameter obj:any\n  Function dynamicComponentFor\n    CallSignature dynamicComponentFor:DynamicComponentReference\n      Parameter vm:VM\n      Parameter args:Arguments\n      Parameter meta:TemplateMeta\n  Function hashToArgs\n    CallSignature hashToArgs:Option<WireFormat.Core.Hash>\n      Parameter hash:Option<WireFormat.Core.Hash>\n  Function inlineComponentMacro\n    CallSignature inlineComponentMacro:boolean\n      Parameter _name:any\n      Parameter params:any\n      Parameter hash:any\n      Parameter builder:any\n  Function isTypeSpecifier\n    CallSignature isTypeSpecifier:boolean\n      Parameter specifier:string\n  Function populateMacros\n    CallSignature populateMacros:void\n      Parameter blocks:BlockMacros\n      Parameter inlines:InlineMacros\n  Function throwNoActionError\n    CallSignature throwNoActionError:void\n      Parameter actionFunc:any\n      Parameter actionFuncReference:Reference<any>\n  ObjectLiteral DEFAULT_HELPERS:object\n    Variable action:buildAction",
+        "hierarchy": "Global @glimmer/application\n  Class Application\n    Constructor constructor\n      ConstructorSignature new Application:Application\n        Parameter options:ApplicationOptions\n    Property _afterRender:function\n      TypeLiteral __type\n        CallSignature __call:void\n    Property _container:Container\n    Property _initialized:boolean\n    Property _initializers:Initializer[]\n    Property _registry:Registry\n    Property _renderPromise:Option<Promise<void>>\n    Property _rendered:boolean\n    Property _rerender:function\n      TypeLiteral __type\n        CallSignature __call:void\n    Property _roots:AppRoot[]\n    Property _rootsIndex:number\n    Property _scheduled:boolean\n    Property document:Document\n    Property env:Environment\n    Property resolver:Resolver\n    Property rootName:string\n    Method _didRender\n      CallSignature _didRender:void\n    Method _scheduleRerender\n      CallSignature _scheduleRerender:void\n    Method renderComponent\n      CallSignature renderComponent:Promise<void>\n        Parameter component:string | ComponentDefinition<Component>\n        Parameter parent:Node\n        Parameter nextSibling:Option<Node>\n    Method scheduleRerender\n      CallSignature scheduleRerender:Promise<void>\n  Class ApplicationRegistry\n    Constructor constructor\n      ConstructorSignature new ApplicationRegistry:ApplicationRegistry\n        Parameter registry:Registry\n        Parameter resolver:Resolver\n    Property _registry:Registry\n    Property _resolver:Resolver\n    Method _toAbsoluteOrTypeSpecifier\n      CallSignature _toAbsoluteOrTypeSpecifier:string\n        Parameter specifier:string\n    Method _toAbsoluteSpecifier\n      CallSignature _toAbsoluteSpecifier:string\n        Parameter specifier:string\n        Parameter referrer:string\n    Method register\n      CallSignature register:void\n        Parameter specifier:string\n        Parameter factory:any\n        Parameter options:RegistrationOptions\n    Method registerInjection\n      CallSignature registerInjection:void\n        Parameter specifier:string\n        Parameter property:string\n        Parameter injection:string\n    Method registerOption\n      CallSignature registerOption:void\n        Parameter specifier:string\n        Parameter option:string\n        Parameter value:any\n    Method registeredInjections\n      CallSignature registeredInjections:Injection[]\n        Parameter specifier:string\n    Method registeredOption\n      CallSignature registeredOption:any\n        Parameter specifier:string\n        Parameter option:string\n    Method registeredOptions\n      CallSignature registeredOptions:any\n        Parameter specifier:string\n    Method registration\n      CallSignature registration:any\n        Parameter specifier:string\n    Method unregister\n      CallSignature unregister:void\n        Parameter specifier:string\n    Method unregisterOption\n      CallSignature unregisterOption:void\n        Parameter specifier:string\n        Parameter option:string\n  Class ArrayIterator\n    Constructor constructor\n      ConstructorSignature new ArrayIterator:ArrayIterator\n        Parameter array:Opaque[]\n        Parameter keyFor:KeyFor<number>\n    Property array:Opaque[]\n    Property keyFor:KeyFor<number>\n    Property position:number\n    Method isEmpty\n      CallSignature isEmpty:boolean\n    Method next\n      CallSignature next:IterationItem<Opaque, number>\n  Class DefaultComponentDefinition\n    Constructor constructor\n      ConstructorSignature new DefaultComponentDefinition:DefaultComponentDefinition\n        Parameter name:string\n        Parameter manager:ComponentManager<any>\n        Parameter ComponentClass:ComponentClass\n    Property ComponentClass:ComponentClass\n    Property manager:ComponentManager<any>\n    Property name:string\n    Method toJSON\n      CallSignature toJSON:string\n  Class DynamicComponentReference\n    Constructor constructor\n      ConstructorSignature new DynamicComponentReference:DynamicComponentReference\n        Parameter nameRef:PathReference<Opaque>\n        Parameter env:GlimmerEnvironment\n        Parameter meta:TemplateMeta\n    Property env:GlimmerEnvironment\n    Property meta:TemplateMeta\n    Property nameRef:PathReference<Opaque>\n    Property tag:TagWrapper<RevisionTag>\n    Method get\n      CallSignature get:PrimitiveReference<undefined>\n    Method value\n      CallSignature value:ComponentDefinition<Opaque>\n  Class DynamicScope\n    Constructor constructor\n      ConstructorSignature new DynamicScope:DynamicScope\n        Parameter bucket:any\n    Property bucket:any\n    Method child\n      CallSignature child:DynamicScope\n    Method get\n      CallSignature get:PathReference<Opaque>\n        Parameter key:string\n    Method set\n      CallSignature set:VersionedPathReference<void | __type>\n        Parameter key:string\n        Parameter reference:PathReference<Opaque>\n  Class EmptyIterator\n    Method isEmpty\n      CallSignature isEmpty:boolean\n    Method next\n      CallSignature next:IterationItem<Opaque, Opaque>\n  Class Environment\n    Constructor constructor\n      ConstructorSignature new Environment:Environment\n        Parameter options:EnvironmentOptions\n    Property appendOperations:DOMTreeConstruction\n    Property components:Dict<ComponentDefinition<void | __type>>\n    Property constants:Constants\n    Property helpers:Dict<Helper>\n    Property managers:Dict<ComponentManager<void | __type>>\n    Property modifiers:Dict<ModifierManager<void | __type>>\n    Property program:Program\n    Property updateOperations:DOMChanges\n    Property uselessAnchor:HTMLAnchorElement\n    Method attributeFor\n      CallSignature attributeFor:AttributeManager\n        Parameter element:Element\n        Parameter attr:string\n        Parameter isTrusting:boolean\n        Parameter namespace:string\n    Method begin\n      CallSignature begin:void\n    Method commit\n      CallSignature commit:void\n    Method didCreate\n      CallSignature didCreate<T>:void\n        TypeParameter T\n        Parameter component:T\n        Parameter manager:ComponentManager<T>\n    Method didDestroy\n      CallSignature didDestroy:void\n        Parameter d:Destroyable\n    Method didUpdate\n      CallSignature didUpdate<T>:void\n        TypeParameter T\n        Parameter component:T\n        Parameter manager:ComponentManager<T>\n    Method getAppendOperations\n      CallSignature getAppendOperations:DOMTreeConstruction\n    Method getComponentDefinition\n      CallSignature getComponentDefinition:ComponentDefinition<Component>\n        Parameter name:string\n        Parameter meta:TemplateMeta\n    Method getDOM\n      CallSignature getDOM:DOMChanges\n    Method getIdentity\n      CallSignature getIdentity:string\n        Parameter object:HasGuid\n    Method hasComponentDefinition\n      CallSignature hasComponentDefinition:boolean\n        Parameter name:string\n        Parameter meta:TemplateMeta\n    Method hasHelper\n      CallSignature hasHelper:boolean\n        Parameter name:string\n        Parameter meta:TemplateMeta\n    Method hasModifier\n      CallSignature hasModifier:boolean\n        Parameter modifierName:string\n        Parameter blockMeta:TemplateMeta\n    Method hasPartial\n      CallSignature hasPartial:boolean\n    Method iterableFor\n      CallSignature iterableFor:OpaqueIterable\n        Parameter ref:Reference<Opaque>\n        Parameter keyPath:string\n    Method lookupHelper\n      CallSignature lookupHelper:GlimmerHelper\n        Parameter name:string\n        Parameter meta:TemplateMeta\n    Method lookupModifier\n      CallSignature lookupModifier:ModifierManager<Opaque>\n        Parameter modifierName:string\n        Parameter blockMeta:TemplateMeta\n    Method lookupPartial\n      CallSignature lookupPartial:any\n    Method macros\n      CallSignature macros:object\n        TypeLiteral __type\n          Variable blocks:BlockMacros\n          Variable inlines:InlineMacros\n    Method managerFor\n      CallSignature managerFor:ComponentManager<Component>\n        Parameter managerId:string\n    Method populateBuiltins\n      CallSignature populateBuiltins:object\n        TypeLiteral __type\n          Variable blocks:Blocks\n          Variable inlines:Inlines\n    Method protocolForURL\n      CallSignature protocolForURL:string\n        Parameter url:string\n    Method registerComponent\n      CallSignature registerComponent:ComponentDefinition<Component>\n        Parameter name:string\n        Parameter templateSpecifier:string\n        Parameter meta:TemplateMeta\n        Parameter owner:Owner\n    Method registerHelper\n      CallSignature registerHelper:GlimmerHelper\n        Parameter specifier:string\n        Parameter owner:Owner\n    Method scheduleInstallModifier\n      CallSignature scheduleInstallModifier<T>:void\n        TypeParameter T\n        Parameter modifier:T\n        Parameter manager:ModifierManager<T>\n    Method scheduleUpdateModifier\n      CallSignature scheduleUpdateModifier<T>:void\n        TypeParameter T\n        Parameter modifier:T\n        Parameter manager:ModifierManager<T>\n    Method toConditionalReference\n      CallSignature toConditionalReference:Reference<boolean>\n        Parameter reference:Reference<Opaque>\n    Method create\n      CallSignature create:Environment\n        Parameter options:EnvironmentOptions\n  Class HelperReference\n    Constructor constructor\n      ConstructorSignature new HelperReference:HelperReference\n        Parameter helper:UserHelper\n        Parameter args:Arguments\n    Property args:CapturedArguments\n    Property helper:UserHelper\n    Property tag:TagWrapper<any>\n    Method get\n      CallSignature get:SimplePathReference<Opaque>\n        Parameter prop:string\n    Method value\n      CallSignature value:any\n  Class Iterable\n    Constructor constructor\n      ConstructorSignature new Iterable:Iterable\n        Parameter ref:Reference<Opaque>\n        Parameter keyFor:KeyFor<Opaque>\n    Property keyFor:KeyFor<Opaque>\n    Property ref:Reference<Opaque>\n    Property tag:Tag\n    Method iterate\n      CallSignature iterate:OpaqueIterator\n    Method memoReferenceFor\n      CallSignature memoReferenceFor:UpdatableReference<Opaque>\n        Parameter item:IterationItem<Opaque, Opaque>\n    Method updateMemoReference\n      CallSignature updateMemoReference:void\n        Parameter reference:UpdatableReference<Opaque>\n        Parameter item:IterationItem<Opaque, Opaque>\n    Method updateValueReference\n      CallSignature updateValueReference:void\n        Parameter reference:UpdatableReference<Opaque>\n        Parameter item:IterationItem<Opaque, Opaque>\n    Method valueReferenceFor\n      CallSignature valueReferenceFor:UpdatableReference<Opaque>\n        Parameter item:IterationItem<Opaque, Opaque>\n  Class ObjectKeysIterator\n    Constructor constructor\n      ConstructorSignature new ObjectKeysIterator:ObjectKeysIterator\n        Parameter keys:string[]\n        Parameter values:Opaque[]\n        Parameter keyFor:KeyFor<string>\n    Property keyFor:KeyFor<string>\n    Property keys:string[]\n    Property position:number\n    Property values:Opaque[]\n    Method isEmpty\n      CallSignature isEmpty:boolean\n    Method next\n      CallSignature next:IterationItem<Opaque, string>\n  Class SimplePathReference<T>\n    TypeParameter T\n    Constructor constructor\n      ConstructorSignature new SimplePathReference:SimplePathReference\n        Parameter parent:Reference<T>\n        Parameter property:string\n    Property parent:Reference<T>\n    Property property:string\n    Property tag:TagWrapper<any>\n    Method get\n      CallSignature get:PathReference<Opaque>\n        Parameter prop:string\n    Method value\n      CallSignature value:T\n  Interface AppRoot\n    Property component:string | ComponentDefinition<Component>\n    Property id:number\n    Property nextSibling:Option<Node>\n    Property parent:Node\n  Interface ApplicationOptions\n    Property document:Document\n    Property resolver:Resolver\n    Property rootName:string\n  Interface ComponentDefinitionCreator\n    Method createComponentDefinition\n      CallSignature createComponentDefinition:ComponentDefinition<Component>\n        Parameter name:string\n        Parameter template:Template<TemplateMeta>\n        Parameter componentFactory:Factory<Component>\n  Interface EnvironmentOptions\n    Property appendOperations:DOMTreeConstruction\n    Property document:HTMLDocument\n  Interface ExtendedTemplateMeta\n    Property <template-meta>:true\n    Property managerId:string\n    Property moduleName:string\n    Property specifier:string\n  Interface Initializer\n    Property name:string\n    Method initialize\n      CallSignature initialize:void\n        Parameter registry:RegistryWriter\n  TypeAlias KeyFor:function\n    TypeLiteral __type\n      CallSignature __call:string\n        Parameter item:Opaque\n        Parameter index:T\n  TypeAlias UserHelper:function\n    TypeLiteral __type\n      CallSignature __call:any\n        Parameter args:ReadonlyArray<Opaque>\n        Parameter named:Dict<Opaque>\n  Variable DEFAULT_MANAGER:\"main\"\n  Variable EMPTY_ITERATOR:EmptyIterator\n  Function NOOP\n    CallSignature NOOP:void\n  Function blockComponentMacro\n    CallSignature blockComponentMacro:boolean\n      Parameter params:any\n      Parameter hash:any\n      Parameter template:any\n      Parameter inverse:any\n      Parameter builder:any\n  Function buildAction\n    CallSignature buildAction:ConstReference<action>\n      Parameter vm:VM\n      Parameter _args:Arguments\n  Function buildUserHelper\n    CallSignature buildUserHelper:GlimmerHelper\n      Parameter helperFunc:any\n  Function canCreateComponentDefinition\n    CallSignature canCreateComponentDefinition:boolean\n      Parameter manager:ComponentDefinitionCreator | ComponentManager<Component>\n  Function debugInfoForReference\n    CallSignature debugInfoForReference:string\n      Parameter reference:any\n  Function debugName\n    CallSignature debugName:any\n      Parameter obj:any\n  Function dynamicComponentFor\n    CallSignature dynamicComponentFor:DynamicComponentReference\n      Parameter vm:VM\n      Parameter args:Arguments\n      Parameter meta:TemplateMeta\n  Function hashToArgs\n    CallSignature hashToArgs:Option<WireFormat.Core.Hash>\n      Parameter hash:Option<WireFormat.Core.Hash>\n  Function inlineComponentMacro\n    CallSignature inlineComponentMacro:boolean\n      Parameter _name:any\n      Parameter params:any\n      Parameter hash:any\n      Parameter builder:any\n  Function isTypeSpecifier\n    CallSignature isTypeSpecifier:boolean\n      Parameter specifier:string\n  Function populateMacros\n    CallSignature populateMacros:void\n      Parameter blocks:BlockMacros\n      Parameter inlines:InlineMacros\n  Function throwNoActionError\n    CallSignature throwNoActionError:void\n      Parameter actionFunc:any\n      Parameter actionFuncReference:Reference<any>\n  ObjectLiteral DEFAULT_HELPERS:object\n    Variable action:buildAction",
         "packageInfo": {
           "name": "@glimmer/application",
           "version": "0.4.0",
@@ -9157,7 +9471,8 @@
             "preversion": "npm test",
             "prepublish": "npm run build",
             "postpublish": "git push origin master --tags",
-            "test": "ember test"
+            "test": "ember test",
+            "problems": "tsc -p tsconfig.json --noEmit"
           },
           "dependencies": {
             "@glimmer/di": "^0.1.9",
@@ -9168,10 +9483,12 @@
             "@glimmer/util": "^0.23.0-alpha.6"
           },
           "devDependencies": {
-            "@glimmer/build": "^0.6.0",
+            "@glimmer/build": "^0.6.2",
             "@glimmer/compiler": "^0.23.0-alpha.6",
             "@glimmer/wire-format": "^0.23.0-alpha.6",
+            "ember-build-utilities": "^0.1.1",
             "ember-cli": "^2.12.0",
+            "simple-dom": "^0.3.2",
             "testem": "^1.13.0",
             "typescript": "^2.2.1"
           }
@@ -9199,20 +9516,20 @@
                 "fileName": "iterable.ts",
                 "line": 17,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L17"
+                "url": null
               },
               {
                 "fileName": "environment.ts",
                 "line": 39,
                 "character": 11,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L39"
+                "url": null
               }
             ],
             "typeInfo": {
               "isArray": false,
               "name": "function",
               "declaration": {
-                "id": "671",
+                "id": "684",
                 "type": "type-literal",
                 "attributes": {
                   "name": "__type",
@@ -9227,7 +9544,7 @@
                       "fileName": "environment.ts",
                       "line": 39,
                       "character": 16,
-                      "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L39"
+                      "url": null
                     }
                   ],
                   "callSignatures": [
@@ -9244,7 +9561,7 @@
                           "fileName": "environment.ts",
                           "line": 39,
                           "character": 16,
-                          "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L39"
+                          "url": null
                         }
                       ],
                       "typeInfo": {
@@ -9304,7 +9621,7 @@
                     "fileName": "environment.ts",
                     "line": 39,
                     "character": 16,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L39"
+                    "url": null
                   }
                 ],
                 "callSignatures": [
@@ -9321,7 +9638,7 @@
                         "fileName": "environment.ts",
                         "line": 39,
                         "character": 16,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L39"
+                        "url": null
                       }
                     ],
                     "typeInfo": {
@@ -9388,14 +9705,14 @@
                 "fileName": "helpers/user-helper.ts",
                 "line": 19,
                 "character": 22,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L19"
+                "url": null
               }
             ],
             "typeInfo": {
               "isArray": false,
               "name": "function",
               "declaration": {
-                "id": "533",
+                "id": "546",
                 "type": "type-literal",
                 "attributes": {
                   "name": "__type",
@@ -9410,7 +9727,7 @@
                       "fileName": "helpers/user-helper.ts",
                       "line": 19,
                       "character": 24,
-                      "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L19"
+                      "url": null
                     }
                   ],
                   "callSignatures": [
@@ -9427,7 +9744,7 @@
                           "fileName": "helpers/user-helper.ts",
                           "line": 19,
                           "character": 24,
-                          "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L19"
+                          "url": null
                         }
                       ],
                       "typeInfo": {
@@ -9487,7 +9804,7 @@
                     "fileName": "helpers/user-helper.ts",
                     "line": 19,
                     "character": 24,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L19"
+                    "url": null
                   }
                 ],
                 "callSignatures": [
@@ -9504,7 +9821,7 @@
                         "fileName": "helpers/user-helper.ts",
                         "line": 19,
                         "character": 24,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L19"
+                        "url": null
                       }
                     ],
                     "typeInfo": {
@@ -9573,7 +9890,7 @@
                 "fileName": "environment.ts",
                 "line": 52,
                 "character": 21,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L52"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -9602,14 +9919,14 @@
                 "fileName": "iterable.ts",
                 "line": 89,
                 "character": 20,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L89"
+                "url": null
               }
             ],
             "typeInfo": {
               "isArray": false,
               "name": "EmptyIterator",
               "link": {
-                "id": "410",
+                "id": "423",
                 "type": "class",
                 "slug": "emptyiterator",
                 "sources": [
@@ -9617,11 +9934,11 @@
                     "fileName": "iterable.ts",
                     "line": 79,
                     "character": 19,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L79"
+                    "url": null
                   }
                 ],
                 "parent": {
-                  "id": "317",
+                  "id": "330",
                   "type": "0",
                   "slug": "_glimmer_application",
                   "sources": null
@@ -9652,7 +9969,7 @@
                 "fileName": "environment.ts",
                 "line": 53,
                 "character": 21,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L53"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -9681,14 +9998,14 @@
                     "fileName": "environment.ts",
                     "line": 54,
                     "character": 8,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L54"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "buildAction",
                   "link": {
-                    "id": "491",
+                    "id": "504",
                     "type": "function",
                     "slug": "buildaction",
                     "sources": [
@@ -9696,11 +10013,11 @@
                         "fileName": "helpers/action.ts",
                         "line": 4,
                         "character": 35,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/action.ts#L4"
+                        "url": null
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -9722,51 +10039,51 @@
           "data": [
             {
               "type": "class",
-              "id": "698"
+              "id": "712"
             },
             {
               "type": "class",
-              "id": "318"
+              "id": "331"
             },
             {
               "type": "class",
-              "id": "384"
+              "id": "397"
             },
             {
               "type": "class",
-              "id": "543"
+              "id": "556"
             },
             {
               "type": "class",
-              "id": "456"
+              "id": "469"
             },
             {
               "type": "class",
-              "id": "370"
+              "id": "383"
             },
             {
               "type": "class",
-              "id": "410"
+              "id": "423"
             },
             {
               "type": "class",
-              "id": "554"
+              "id": "567"
             },
             {
               "type": "class",
-              "id": "519"
+              "id": "532"
             },
             {
               "type": "class",
-              "id": "415"
+              "id": "428"
             },
             {
               "type": "class",
-              "id": "396"
+              "id": "409"
             },
             {
               "type": "class",
-              "id": "505"
+              "id": "518"
             }
           ]
         },
@@ -9774,27 +10091,27 @@
           "data": [
             {
               "type": "interface",
-              "id": "693"
+              "id": "707"
             },
             {
               "type": "interface",
-              "id": "685"
+              "id": "698"
             },
             {
               "type": "interface",
-              "id": "450"
+              "id": "463"
             },
             {
               "type": "interface",
-              "id": "540"
+              "id": "553"
             },
             {
               "type": "interface",
-              "id": "445"
+              "id": "458"
             },
             {
               "type": "interface",
-              "id": "688"
+              "id": "702"
             }
           ]
         },
@@ -9802,27 +10119,7 @@
           "data": [
             {
               "type": "function",
-              "id": "470"
-            },
-            {
-              "type": "function",
-              "id": "491"
-            },
-            {
-              "type": "function",
-              "id": "537"
-            },
-            {
-              "type": "function",
-              "id": "682"
-            },
-            {
-              "type": "function",
-              "id": "499"
-            },
-            {
-              "type": "function",
-              "id": "502"
+              "id": "771"
             },
             {
               "type": "function",
@@ -9830,30 +10127,54 @@
             },
             {
               "type": "function",
-              "id": "488"
+              "id": "504"
             },
             {
               "type": "function",
-              "id": "477"
+              "id": "550"
             },
             {
               "type": "function",
-              "id": "367"
+              "id": "695"
             },
             {
               "type": "function",
-              "id": "678"
+              "id": "512"
             },
             {
               "type": "function",
-              "id": "495"
+              "id": "515"
+            },
+            {
+              "type": "function",
+              "id": "496"
+            },
+            {
+              "type": "function",
+              "id": "501"
+            },
+            {
+              "type": "function",
+              "id": "490"
+            },
+            {
+              "type": "function",
+              "id": "380"
+            },
+            {
+              "type": "function",
+              "id": "691"
+            },
+            {
+              "type": "function",
+              "id": "508"
             }
           ]
         }
       }
     },
     {
-      "id": "698",
+      "id": "712",
       "type": "class",
       "attributes": {
         "name": "Application",
@@ -9870,7 +10191,7 @@
         },
         "alias": "application",
         "fullName": "Application",
-        "hierarchy": "Class Application\n  Constructor constructor\n    ConstructorSignature new Application:Application\n      Parameter options:ApplicationOptions\n  Property _container:Container\n  Property _initialized:boolean\n  Property _initializers:Initializer[]\n  Property _registry:Registry\n  Property _renderResult:RenderResult\n  Property _rendered:boolean\n  Property _roots:AppRoot[]\n  Property _rootsIndex:number\n  Property _scheduled:boolean\n  Property env:Environment\n  Property resolver:Resolver\n  Property rootName:string\n  Method renderComponent\n    CallSignature renderComponent:void\n      Parameter component:string | ComponentDefinition<Component>\n      Parameter parent:Node\n      Parameter nextSibling:Option<Node>",
+        "hierarchy": "Class Application\n  Constructor constructor\n    ConstructorSignature new Application:Application\n      Parameter options:ApplicationOptions\n  Property _afterRender:function\n    TypeLiteral __type\n      CallSignature __call:void\n  Property _container:Container\n  Property _initialized:boolean\n  Property _initializers:Initializer[]\n  Property _registry:Registry\n  Property _renderPromise:Option<Promise<void>>\n  Property _rendered:boolean\n  Property _rerender:function\n    TypeLiteral __type\n      CallSignature __call:void\n  Property _roots:AppRoot[]\n  Property _rootsIndex:number\n  Property _scheduled:boolean\n  Property document:Document\n  Property env:Environment\n  Property resolver:Resolver\n  Property rootName:string\n  Method _didRender\n    CallSignature _didRender:void\n  Method _scheduleRerender\n    CallSignature _scheduleRerender:void\n  Method renderComponent\n    CallSignature renderComponent:Promise<void>\n      Parameter component:string | ComponentDefinition<Component>\n      Parameter parent:Node\n      Parameter nextSibling:Option<Node>\n  Method scheduleRerender\n    CallSignature scheduleRerender:Promise<void>",
         "kindString": "Class",
         "implementedTypes": [
           {
@@ -9881,7 +10202,7 @@
         "sources": [
           {
             "fileName": "application.ts",
-            "line": 45,
+            "line": 47,
             "character": 32,
             "url": null
           }
@@ -9906,8 +10227,8 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 59,
-                "character": 31,
+                "line": 62,
+                "character": 48,
                 "url": null
               }
             ],
@@ -9923,8 +10244,8 @@
                 "sources": [
                   {
                     "fileName": "application.ts",
-                    "line": 59,
-                    "character": 31,
+                    "line": 62,
+                    "character": 48,
                     "url": null
                   }
                 ],
@@ -9932,19 +10253,19 @@
                   "isArray": false,
                   "name": "Application",
                   "link": {
-                    "id": "698",
+                    "id": "712",
                     "type": "class",
                     "slug": "application",
                     "sources": [
                       {
                         "fileName": "application.ts",
-                        "line": 45,
+                        "line": 47,
                         "character": 32,
                         "url": null
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -9967,19 +10288,19 @@
                       "isArray": false,
                       "name": "ApplicationOptions",
                       "link": {
-                        "id": "685",
+                        "id": "698",
                         "type": "interface",
                         "slug": "applicationoptions",
                         "sources": [
                           {
                             "fileName": "application.ts",
-                            "line": 28,
+                            "line": 29,
                             "character": 35,
                             "url": null
                           }
                         ],
                         "parent": {
-                          "id": "317",
+                          "id": "330",
                           "type": "0",
                           "slug": "_glimmer_application",
                           "sources": null
@@ -9993,6 +10314,121 @@
           }
         ],
         "properties": [
+          {
+            "name": "_afterRender",
+            "slug": "_afterrender",
+            "flags": {
+              "isExported": true,
+              "isExternal": false,
+              "isOptional": false,
+              "isPrivate": true,
+              "isPublic": false,
+              "isProtected": false,
+              "isStatic": false
+            },
+            "alias": "_afterrender",
+            "fullName": "Application._afterRender",
+            "hierarchy": "Property _afterRender:function\n  TypeLiteral __type\n    CallSignature __call:void",
+            "kindString": "Property",
+            "sources": [
+              {
+                "fileName": "application.ts",
+                "line": 61,
+                "character": 22,
+                "url": null
+              }
+            ],
+            "typeInfo": {
+              "isArray": false,
+              "name": "function",
+              "declaration": {
+                "id": "729",
+                "type": "type-literal",
+                "attributes": {
+                  "name": "__type",
+                  "slug": "__type",
+                  "flags": {},
+                  "alias": "__type",
+                  "fullName": "Application._afterRender.__type",
+                  "hierarchy": "TypeLiteral __type\n  CallSignature __call:void",
+                  "kindString": "Type literal",
+                  "sources": [
+                    {
+                      "fileName": "application.ts",
+                      "line": 61,
+                      "character": 23,
+                      "url": null
+                    }
+                  ],
+                  "callSignatures": [
+                    {
+                      "name": "__call",
+                      "slug": "__call",
+                      "flags": {},
+                      "alias": "__call",
+                      "fullName": "Application._afterRender.__type.__call",
+                      "hierarchy": "CallSignature __call:void",
+                      "kindString": "Call signature",
+                      "sources": [
+                        {
+                          "fileName": "application.ts",
+                          "line": 61,
+                          "character": 23,
+                          "url": null
+                        }
+                      ],
+                      "typeInfo": {
+                        "isArray": false,
+                        "name": "void"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "typeLiterals": [
+              {
+                "name": "__type",
+                "slug": "__type",
+                "flags": {},
+                "alias": "__type",
+                "fullName": "Application._afterRender.__type",
+                "hierarchy": "TypeLiteral __type\n  CallSignature __call:void",
+                "kindString": "Type literal",
+                "sources": [
+                  {
+                    "fileName": "application.ts",
+                    "line": 61,
+                    "character": 23,
+                    "url": null
+                  }
+                ],
+                "callSignatures": [
+                  {
+                    "name": "__call",
+                    "slug": "__call",
+                    "flags": {},
+                    "alias": "__call",
+                    "fullName": "Application._afterRender.__type.__call",
+                    "hierarchy": "CallSignature __call:void",
+                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "application.ts",
+                        "line": 61,
+                        "character": 23,
+                        "url": null
+                      }
+                    ],
+                    "typeInfo": {
+                      "isArray": false,
+                      "name": "void"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
           {
             "name": "_container",
             "slug": "_container",
@@ -10012,7 +10448,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 52,
+                "line": 55,
                 "character": 20,
                 "url": null
               }
@@ -10041,7 +10477,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 59,
+                "line": 57,
                 "character": 22,
                 "url": null
               }
@@ -10070,7 +10506,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 58,
+                "line": 56,
                 "character": 23,
                 "url": null
               }
@@ -10079,19 +10515,19 @@
               "isArray": true,
               "name": "Initializer",
               "link": {
-                "id": "688",
+                "id": "702",
                 "type": "interface",
                 "slug": "initializer",
                 "sources": [
                   {
                     "fileName": "application.ts",
-                    "line": 33,
+                    "line": 35,
                     "character": 28,
                     "url": null
                   }
                 ],
                 "parent": {
-                  "id": "317",
+                  "id": "330",
                   "type": "0",
                   "slug": "_glimmer_application",
                   "sources": null
@@ -10118,7 +10554,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 51,
+                "line": 54,
                 "character": 19,
                 "url": null
               }
@@ -10129,8 +10565,8 @@
             }
           },
           {
-            "name": "_renderResult",
-            "slug": "_renderresult",
+            "name": "_renderPromise",
+            "slug": "_renderpromise",
             "flags": {
               "isExported": true,
               "isExternal": false,
@@ -10140,21 +10576,21 @@
               "isProtected": false,
               "isStatic": false
             },
-            "alias": "_renderresult",
-            "fullName": "Application._renderResult",
-            "hierarchy": "Property _renderResult:RenderResult",
+            "alias": "_renderpromise",
+            "fullName": "Application._renderPromise",
+            "hierarchy": "Property _renderPromise:Option<Promise<void>>",
             "kindString": "Property",
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 53,
-                "character": 23,
+                "line": 62,
+                "character": 24,
                 "url": null
               }
             ],
             "typeInfo": {
               "isArray": false,
-              "name": "RenderResult"
+              "name": "Option"
             }
           },
           {
@@ -10176,19 +10612,130 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 55,
+                "line": 58,
                 "character": 19,
                 "url": null
               }
             ],
-            "comment": {
-              "shortText": "<p>Whether the initial render has completed.</p>\n",
-              "text": "<p>Whether the initial render has completed.</p>\n"
-            },
             "typeInfo": {
               "isArray": false,
               "name": "boolean"
             }
+          },
+          {
+            "name": "_rerender",
+            "slug": "_rerender",
+            "flags": {
+              "isExported": true,
+              "isExternal": false,
+              "isOptional": false,
+              "isPrivate": true,
+              "isPublic": false,
+              "isProtected": false,
+              "isStatic": false
+            },
+            "alias": "_rerender",
+            "fullName": "Application._rerender",
+            "hierarchy": "Property _rerender:function\n  TypeLiteral __type\n    CallSignature __call:void",
+            "kindString": "Property",
+            "sources": [
+              {
+                "fileName": "application.ts",
+                "line": 60,
+                "character": 19,
+                "url": null
+              }
+            ],
+            "typeInfo": {
+              "isArray": false,
+              "name": "function",
+              "declaration": {
+                "id": "726",
+                "type": "type-literal",
+                "attributes": {
+                  "name": "__type",
+                  "slug": "__type-1",
+                  "flags": {},
+                  "alias": "__type-1",
+                  "fullName": "Application._rerender.__type",
+                  "hierarchy": "TypeLiteral __type\n  CallSignature __call:void",
+                  "kindString": "Type literal",
+                  "sources": [
+                    {
+                      "fileName": "application.ts",
+                      "line": 60,
+                      "character": 20,
+                      "url": null
+                    }
+                  ],
+                  "callSignatures": [
+                    {
+                      "name": "__call",
+                      "slug": "__call-1",
+                      "flags": {},
+                      "alias": "__call-1",
+                      "fullName": "Application._rerender.__type.__call",
+                      "hierarchy": "CallSignature __call:void",
+                      "kindString": "Call signature",
+                      "sources": [
+                        {
+                          "fileName": "application.ts",
+                          "line": 60,
+                          "character": 20,
+                          "url": null
+                        }
+                      ],
+                      "typeInfo": {
+                        "isArray": false,
+                        "name": "void"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "typeLiterals": [
+              {
+                "name": "__type",
+                "slug": "__type-1",
+                "flags": {},
+                "alias": "__type-1",
+                "fullName": "Application._rerender.__type",
+                "hierarchy": "TypeLiteral __type\n  CallSignature __call:void",
+                "kindString": "Type literal",
+                "sources": [
+                  {
+                    "fileName": "application.ts",
+                    "line": 60,
+                    "character": 20,
+                    "url": null
+                  }
+                ],
+                "callSignatures": [
+                  {
+                    "name": "__call",
+                    "slug": "__call-1",
+                    "flags": {},
+                    "alias": "__call-1",
+                    "fullName": "Application._rerender.__type.__call",
+                    "hierarchy": "CallSignature __call:void",
+                    "kindString": "Call signature",
+                    "sources": [
+                      {
+                        "fileName": "application.ts",
+                        "line": 60,
+                        "character": 20,
+                        "url": null
+                      }
+                    ],
+                    "typeInfo": {
+                      "isArray": false,
+                      "name": "void"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           {
             "name": "_roots",
@@ -10209,7 +10756,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 49,
+                "line": 52,
                 "character": 16,
                 "url": null
               }
@@ -10218,19 +10765,19 @@
               "isArray": true,
               "name": "AppRoot",
               "link": {
-                "id": "693",
+                "id": "707",
                 "type": "interface",
                 "slug": "approot",
                 "sources": [
                   {
                     "fileName": "application.ts",
-                    "line": 38,
+                    "line": 40,
                     "character": 24,
                     "url": null
                   }
                 ],
                 "parent": {
-                  "id": "317",
+                  "id": "330",
                   "type": "0",
                   "slug": "_glimmer_application",
                   "sources": null
@@ -10257,7 +10804,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 50,
+                "line": 53,
                 "character": 21,
                 "url": null
               }
@@ -10286,18 +10833,43 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 57,
+                "line": 59,
                 "character": 20,
                 "url": null
               }
             ],
-            "comment": {
-              "shortText": "<p>Whether a re-render has been scheduled.</p>\n",
-              "text": "<p>Whether a re-render has been scheduled.</p>\n"
-            },
             "typeInfo": {
               "isArray": false,
               "name": "boolean"
+            }
+          },
+          {
+            "name": "document",
+            "slug": "document",
+            "flags": {
+              "isExported": true,
+              "isExternal": false,
+              "isOptional": false,
+              "isPrivate": false,
+              "isPublic": true,
+              "isProtected": false,
+              "isStatic": false
+            },
+            "alias": "document",
+            "fullName": "Application.document",
+            "hierarchy": "Property document:Document",
+            "kindString": "Property",
+            "sources": [
+              {
+                "fileName": "application.ts",
+                "line": 50,
+                "character": 17,
+                "url": null
+              }
+            ],
+            "typeInfo": {
+              "isArray": false,
+              "name": "Document"
             }
           },
           {
@@ -10319,7 +10891,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 48,
+                "line": 51,
                 "character": 12,
                 "url": null
               }
@@ -10328,7 +10900,7 @@
               "isArray": false,
               "name": "Environment",
               "link": {
-                "id": "554",
+                "id": "567",
                 "type": "class",
                 "slug": "environment",
                 "sources": [
@@ -10336,11 +10908,11 @@
                     "fileName": "environment.ts",
                     "line": 57,
                     "character": 32,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L57"
+                    "url": null
                   }
                 ],
                 "parent": {
-                  "id": "317",
+                  "id": "330",
                   "type": "0",
                   "slug": "_glimmer_application",
                   "sources": null
@@ -10367,7 +10939,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 47,
+                "line": 49,
                 "character": 17,
                 "url": null
               }
@@ -10396,7 +10968,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 46,
+                "line": 48,
                 "character": 17,
                 "url": null
               }
@@ -10408,6 +10980,102 @@
           }
         ],
         "methods": [
+          {
+            "name": "_didRender",
+            "slug": "_didrender",
+            "flags": {
+              "isExported": true,
+              "isExternal": false,
+              "isOptional": false,
+              "isPrivate": false,
+              "isPublic": false,
+              "isProtected": false,
+              "isStatic": false
+            },
+            "alias": "_didrender",
+            "fullName": "Application._didRender",
+            "hierarchy": "Method _didRender\n  CallSignature _didRender:void",
+            "kindString": "Method",
+            "sources": [
+              {
+                "fileName": "application.ts",
+                "line": 159,
+                "character": 12,
+                "url": null
+              }
+            ],
+            "callSignatures": [
+              {
+                "name": "_didRender",
+                "slug": "_didrender-1",
+                "flags": {},
+                "alias": "_didrender-1",
+                "fullName": "Application._didRender._didRender",
+                "hierarchy": "CallSignature _didRender:void",
+                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "application.ts",
+                    "line": 159,
+                    "character": 12,
+                    "url": null
+                  }
+                ],
+                "typeInfo": {
+                  "isArray": false,
+                  "name": "void"
+                }
+              }
+            ]
+          },
+          {
+            "name": "_scheduleRerender",
+            "slug": "_schedulererender",
+            "flags": {
+              "isExported": true,
+              "isExternal": false,
+              "isOptional": false,
+              "isPrivate": false,
+              "isPublic": false,
+              "isProtected": false,
+              "isStatic": false
+            },
+            "alias": "_schedulererender",
+            "fullName": "Application._scheduleRerender",
+            "hierarchy": "Method _scheduleRerender\n  CallSignature _scheduleRerender:void",
+            "kindString": "Method",
+            "sources": [
+              {
+                "fileName": "application.ts",
+                "line": 192,
+                "character": 19,
+                "url": null
+              }
+            ],
+            "callSignatures": [
+              {
+                "name": "_scheduleRerender",
+                "slug": "_schedulererender-1",
+                "flags": {},
+                "alias": "_schedulererender-1",
+                "fullName": "Application._scheduleRerender._scheduleRerender",
+                "hierarchy": "CallSignature _scheduleRerender:void",
+                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "application.ts",
+                    "line": 192,
+                    "character": 19,
+                    "url": null
+                  }
+                ],
+                "typeInfo": {
+                  "isArray": false,
+                  "name": "void"
+                }
+              }
+            ]
+          },
           {
             "name": "renderComponent",
             "slug": "rendercomponent",
@@ -10422,12 +11090,12 @@
             },
             "alias": "rendercomponent",
             "fullName": "Application.renderComponent",
-            "hierarchy": "Method renderComponent\n  CallSignature renderComponent:void\n    Parameter component:string | ComponentDefinition<Component>\n    Parameter parent:Node\n    Parameter nextSibling:Option<Node>",
+            "hierarchy": "Method renderComponent\n  CallSignature renderComponent:Promise<void>\n    Parameter component:string | ComponentDefinition<Component>\n    Parameter parent:Node\n    Parameter nextSibling:Option<Node>",
             "kindString": "Method",
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 143,
+                "line": 169,
                 "character": 17,
                 "url": null
               }
@@ -10439,19 +11107,19 @@
                 "flags": {},
                 "alias": "rendercomponent-1",
                 "fullName": "Application.renderComponent.renderComponent",
-                "hierarchy": "CallSignature renderComponent:void\n  Parameter component:string | ComponentDefinition<Component>\n  Parameter parent:Node\n  Parameter nextSibling:Option<Node>",
+                "hierarchy": "CallSignature renderComponent:Promise<void>\n  Parameter component:string | ComponentDefinition<Component>\n  Parameter parent:Node\n  Parameter nextSibling:Option<Node>",
                 "kindString": "Call signature",
                 "sources": [
                   {
                     "fileName": "application.ts",
-                    "line": 143,
+                    "line": 169,
                     "character": 17,
                     "url": null
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
-                  "name": "void"
+                  "name": "Promise"
                 },
                 "parameters": [
                   {
@@ -10515,12 +11183,60 @@
                 ]
               }
             ]
+          },
+          {
+            "name": "scheduleRerender",
+            "slug": "schedulererender",
+            "flags": {
+              "isExported": true,
+              "isExternal": false,
+              "isOptional": false,
+              "isPrivate": false,
+              "isPublic": false,
+              "isProtected": false,
+              "isStatic": false
+            },
+            "alias": "schedulererender",
+            "fullName": "Application.scheduleRerender",
+            "hierarchy": "Method scheduleRerender\n  CallSignature scheduleRerender:Promise<void>",
+            "kindString": "Method",
+            "sources": [
+              {
+                "fileName": "application.ts",
+                "line": 178,
+                "character": 18,
+                "url": null
+              }
+            ],
+            "callSignatures": [
+              {
+                "name": "scheduleRerender",
+                "slug": "schedulererender-1",
+                "flags": {},
+                "alias": "schedulererender-1",
+                "fullName": "Application.scheduleRerender.scheduleRerender",
+                "hierarchy": "CallSignature scheduleRerender:Promise<void>",
+                "kindString": "Call signature",
+                "sources": [
+                  {
+                    "fileName": "application.ts",
+                    "line": 178,
+                    "character": 18,
+                    "url": null
+                  }
+                ],
+                "typeInfo": {
+                  "isArray": false,
+                  "name": "Promise"
+                }
+              }
+            ]
           }
         ]
       }
     },
     {
-      "id": "318",
+      "id": "331",
       "type": "class",
       "attributes": {
         "name": "ApplicationRegistry",
@@ -10599,7 +11315,7 @@
                   "isArray": false,
                   "name": "ApplicationRegistry",
                   "link": {
-                    "id": "318",
+                    "id": "331",
                     "type": "class",
                     "slug": "applicationregistry",
                     "sources": [
@@ -10611,7 +11327,7 @@
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -11591,7 +12307,7 @@
       }
     },
     {
-      "id": "384",
+      "id": "397",
       "type": "class",
       "attributes": {
         "name": "ArrayIterator",
@@ -11621,7 +12337,7 @@
             "fileName": "iterable.ts",
             "line": 19,
             "character": 19,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L19"
+            "url": null
           }
         ],
         "constructors": [
@@ -11646,7 +12362,7 @@
                 "fileName": "iterable.ts",
                 "line": 22,
                 "character": 23,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L22"
+                "url": null
               }
             ],
             "constructorSignatures": [
@@ -11663,14 +12379,14 @@
                     "fileName": "iterable.ts",
                     "line": 22,
                     "character": 23,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L22"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "ArrayIterator",
                   "link": {
-                    "id": "384",
+                    "id": "397",
                     "type": "class",
                     "slug": "arrayiterator",
                     "sources": [
@@ -11678,11 +12394,11 @@
                         "fileName": "iterable.ts",
                         "line": 19,
                         "character": 19,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L19"
+                        "url": null
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -11721,7 +12437,7 @@
                       "isArray": false,
                       "name": "KeyFor",
                       "link": {
-                        "id": "439",
+                        "id": "452",
                         "type": "type-alias",
                         "slug": "keyfor",
                         "sources": [
@@ -11729,17 +12445,17 @@
                             "fileName": "iterable.ts",
                             "line": 17,
                             "character": 18,
-                            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L17"
+                            "url": null
                           },
                           {
                             "fileName": "environment.ts",
                             "line": 39,
                             "character": 11,
-                            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L39"
+                            "url": null
                           }
                         ],
                         "parent": {
-                          "id": "317",
+                          "id": "330",
                           "type": "0",
                           "slug": "_glimmer_application",
                           "sources": null
@@ -11774,7 +12490,7 @@
                 "fileName": "iterable.ts",
                 "line": 20,
                 "character": 15,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L20"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -11803,14 +12519,14 @@
                 "fileName": "iterable.ts",
                 "line": 21,
                 "character": 16,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L21"
+                "url": null
               }
             ],
             "typeInfo": {
               "isArray": false,
               "name": "KeyFor",
               "link": {
-                "id": "439",
+                "id": "452",
                 "type": "type-alias",
                 "slug": "keyfor",
                 "sources": [
@@ -11818,17 +12534,17 @@
                     "fileName": "iterable.ts",
                     "line": 17,
                     "character": 18,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L17"
+                    "url": null
                   },
                   {
                     "fileName": "environment.ts",
                     "line": 39,
                     "character": 11,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L39"
+                    "url": null
                   }
                 ],
                 "parent": {
-                  "id": "317",
+                  "id": "330",
                   "type": "0",
                   "slug": "_glimmer_application",
                   "sources": null
@@ -11857,7 +12573,7 @@
                 "fileName": "iterable.ts",
                 "line": 22,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L22"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -11888,7 +12604,7 @@
                 "fileName": "iterable.ts",
                 "line": 29,
                 "character": 9,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L29"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -11905,7 +12621,7 @@
                     "fileName": "iterable.ts",
                     "line": 29,
                     "character": 9,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L29"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -11936,7 +12652,7 @@
                 "fileName": "iterable.ts",
                 "line": 33,
                 "character": 6,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L33"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -11953,7 +12669,7 @@
                     "fileName": "iterable.ts",
                     "line": 33,
                     "character": 6,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L33"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -11967,7 +12683,7 @@
       }
     },
     {
-      "id": "543",
+      "id": "556",
       "type": "class",
       "attributes": {
         "name": "DefaultComponentDefinition",
@@ -11997,7 +12713,7 @@
             "fileName": "environment.ts",
             "line": 46,
             "character": 32,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L46"
+            "url": null
           }
         ],
         "constructors": [
@@ -12046,7 +12762,7 @@
                   "isArray": false,
                   "name": "DefaultComponentDefinition",
                   "link": {
-                    "id": "543",
+                    "id": "556",
                     "type": "class",
                     "slug": "defaultcomponentdefinition",
                     "sources": [
@@ -12054,11 +12770,11 @@
                         "fileName": "environment.ts",
                         "line": 46,
                         "character": 32,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L46"
+                        "url": null
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -12113,12 +12829,12 @@
                       "isArray": false,
                       "name": "ComponentClass",
                       "link": {
-                        "id": "553",
+                        "id": "566",
                         "type": "parameter",
                         "slug": "componentclass",
                         "sources": null,
                         "parent": {
-                          "id": "550",
+                          "id": "563",
                           "type": "constructor-signature",
                           "slug": "new_defaultcomponentdefinition",
                           "sources": [
@@ -12167,7 +12883,7 @@
               "isArray": false,
               "name": "ComponentClass",
               "link": {
-                "id": "548",
+                "id": "561",
                 "type": "property",
                 "slug": "componentclass-1",
                 "sources": [
@@ -12179,7 +12895,7 @@
                   }
                 ],
                 "parent": {
-                  "id": "543",
+                  "id": "556",
                   "type": "class",
                   "slug": "defaultcomponentdefinition",
                   "sources": [
@@ -12187,7 +12903,7 @@
                       "fileName": "environment.ts",
                       "line": 46,
                       "character": 32,
-                      "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L46"
+                      "url": null
                     }
                   ]
                 }
@@ -12275,7 +12991,7 @@
                 "fileName": "environment.ts",
                 "line": 47,
                 "character": 8,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L47"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -12292,7 +13008,7 @@
                     "fileName": "environment.ts",
                     "line": 47,
                     "character": 8,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L47"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -12306,7 +13022,7 @@
       }
     },
     {
-      "id": "456",
+      "id": "469",
       "type": "class",
       "attributes": {
         "name": "DynamicComponentReference",
@@ -12336,7 +13052,7 @@
             "fileName": "dynamic-component.ts",
             "line": 46,
             "character": 31,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L46"
+            "url": null
           }
         ],
         "constructors": [
@@ -12361,7 +13077,7 @@
                 "fileName": "dynamic-component.ts",
                 "line": 47,
                 "character": 38,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L47"
+                "url": null
               }
             ],
             "constructorSignatures": [
@@ -12378,14 +13094,14 @@
                     "fileName": "dynamic-component.ts",
                     "line": 47,
                     "character": 38,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L47"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "DynamicComponentReference",
                   "link": {
-                    "id": "456",
+                    "id": "469",
                     "type": "class",
                     "slug": "dynamiccomponentreference",
                     "sources": [
@@ -12393,11 +13109,11 @@
                         "fileName": "dynamic-component.ts",
                         "line": 46,
                         "character": 31,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L46"
+                        "url": null
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -12480,7 +13196,7 @@
                 "fileName": "dynamic-component.ts",
                 "line": 49,
                 "character": 65,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L49"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -12509,7 +13225,7 @@
                 "fileName": "dynamic-component.ts",
                 "line": 49,
                 "character": 99,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L49"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -12538,7 +13254,7 @@
                 "fileName": "dynamic-component.ts",
                 "line": 49,
                 "character": 29,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L49"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -12567,7 +13283,7 @@
                 "fileName": "dynamic-component.ts",
                 "line": 47,
                 "character": 12,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L47"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -12598,7 +13314,7 @@
                 "fileName": "dynamic-component.ts",
                 "line": 65,
                 "character": 5,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L65"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -12615,7 +13331,7 @@
                     "fileName": "dynamic-component.ts",
                     "line": 65,
                     "character": 5,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L65"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -12646,7 +13362,7 @@
                 "fileName": "dynamic-component.ts",
                 "line": 53,
                 "character": 7,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L53"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -12663,7 +13379,7 @@
                     "fileName": "dynamic-component.ts",
                     "line": 53,
                     "character": 7,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L53"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -12677,7 +13393,7 @@
       }
     },
     {
-      "id": "370",
+      "id": "383",
       "type": "class",
       "attributes": {
         "name": "DynamicScope",
@@ -12707,7 +13423,7 @@
             "fileName": "dynamic-scope.ts",
             "line": 12,
             "character": 33,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-scope.ts#L12"
+            "url": null
           }
         ],
         "constructors": [
@@ -12732,7 +13448,7 @@
                 "fileName": "dynamic-scope.ts",
                 "line": 13,
                 "character": 17,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-scope.ts#L13"
+                "url": null
               }
             ],
             "constructorSignatures": [
@@ -12749,14 +13465,14 @@
                     "fileName": "dynamic-scope.ts",
                     "line": 13,
                     "character": 17,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-scope.ts#L13"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "DynamicScope",
                   "link": {
-                    "id": "370",
+                    "id": "383",
                     "type": "class",
                     "slug": "dynamicscope",
                     "sources": [
@@ -12764,11 +13480,11 @@
                         "fileName": "dynamic-scope.ts",
                         "line": 12,
                         "character": 33,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-scope.ts#L12"
+                        "url": null
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -12819,7 +13535,7 @@
                 "fileName": "dynamic-scope.ts",
                 "line": 13,
                 "character": 16,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-scope.ts#L13"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -12850,7 +13566,7 @@
                 "fileName": "dynamic-scope.ts",
                 "line": 31,
                 "character": 7,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-scope.ts#L31"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -12867,14 +13583,14 @@
                     "fileName": "dynamic-scope.ts",
                     "line": 31,
                     "character": 7,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-scope.ts#L31"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "DynamicScope",
                   "link": {
-                    "id": "370",
+                    "id": "383",
                     "type": "class",
                     "slug": "dynamicscope",
                     "sources": [
@@ -12882,11 +13598,11 @@
                         "fileName": "dynamic-scope.ts",
                         "line": 12,
                         "character": 33,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-scope.ts#L12"
+                        "url": null
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -12917,7 +13633,7 @@
                 "fileName": "dynamic-scope.ts",
                 "line": 23,
                 "character": 5,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-scope.ts#L23"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -12934,7 +13650,7 @@
                     "fileName": "dynamic-scope.ts",
                     "line": 23,
                     "character": 5,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-scope.ts#L23"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -12983,7 +13699,7 @@
                 "fileName": "dynamic-scope.ts",
                 "line": 27,
                 "character": 5,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-scope.ts#L27"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -13000,7 +13716,7 @@
                     "fileName": "dynamic-scope.ts",
                     "line": 27,
                     "character": 5,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-scope.ts#L27"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -13048,7 +13764,7 @@
       }
     },
     {
-      "id": "410",
+      "id": "423",
       "type": "class",
       "attributes": {
         "name": "EmptyIterator",
@@ -13078,7 +13794,7 @@
             "fileName": "iterable.ts",
             "line": 79,
             "character": 19,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L79"
+            "url": null
           }
         ],
         "methods": [
@@ -13103,7 +13819,7 @@
                 "fileName": "iterable.ts",
                 "line": 80,
                 "character": 9,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L80"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -13120,7 +13836,7 @@
                     "fileName": "iterable.ts",
                     "line": 80,
                     "character": 9,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L80"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -13151,7 +13867,7 @@
                 "fileName": "iterable.ts",
                 "line": 84,
                 "character": 6,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L84"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -13168,7 +13884,7 @@
                     "fileName": "iterable.ts",
                     "line": 84,
                     "character": 6,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L84"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -13182,7 +13898,7 @@
       }
     },
     {
-      "id": "554",
+      "id": "567",
       "type": "class",
       "attributes": {
         "name": "Environment",
@@ -13212,7 +13928,7 @@
             "fileName": "environment.ts",
             "line": 57,
             "character": 32,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L57"
+            "url": null
           }
         ],
         "constructors": [
@@ -13237,7 +13953,7 @@
                 "fileName": "environment.ts",
                 "line": 69,
                 "character": 3,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L69"
+                "url": null
               }
             ],
             "constructorSignatures": [
@@ -13254,14 +13970,14 @@
                     "fileName": "environment.ts",
                     "line": 69,
                     "character": 3,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L69"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "Environment",
                   "link": {
-                    "id": "554",
+                    "id": "567",
                     "type": "class",
                     "slug": "environment",
                     "sources": [
@@ -13269,11 +13985,11 @@
                         "fileName": "environment.ts",
                         "line": 57,
                         "character": 32,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L57"
+                        "url": null
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -13296,7 +14012,7 @@
                       "isArray": false,
                       "name": "EnvironmentOptions",
                       "link": {
-                        "id": "540",
+                        "id": "553",
                         "type": "interface",
                         "slug": "environmentoptions",
                         "sources": [
@@ -13304,11 +14020,11 @@
                             "fileName": "environment.ts",
                             "line": 41,
                             "character": 35,
-                            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L41"
+                            "url": null
                           }
                         ],
                         "parent": {
-                          "id": "317",
+                          "id": "330",
                           "type": "0",
                           "slug": "_glimmer_application",
                           "sources": null
@@ -13372,7 +14088,7 @@
                 "fileName": "environment.ts",
                 "line": 60,
                 "character": 20,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L60"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -13430,7 +14146,7 @@
                 "fileName": "environment.ts",
                 "line": 58,
                 "character": 17,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L58"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -13459,7 +14175,7 @@
                 "fileName": "environment.ts",
                 "line": 61,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L61"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -13488,7 +14204,7 @@
                 "fileName": "environment.ts",
                 "line": 59,
                 "character": 19,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L59"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -13575,7 +14291,7 @@
                 "fileName": "environment.ts",
                 "line": 62,
                 "character": 23,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L62"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -14116,7 +14832,7 @@
                 "fileName": "environment.ts",
                 "line": 113,
                 "character": 24,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L113"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -14133,7 +14849,7 @@
                     "fileName": "environment.ts",
                     "line": 113,
                     "character": 24,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L113"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -14312,7 +15028,7 @@
                 "fileName": "environment.ts",
                 "line": 109,
                 "character": 24,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L109"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -14329,7 +15045,7 @@
                     "fileName": "environment.ts",
                     "line": 109,
                     "character": 24,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L109"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -14394,7 +15110,7 @@
                 "fileName": "environment.ts",
                 "line": 158,
                 "character": 11,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L158"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -14411,7 +15127,7 @@
                     "fileName": "environment.ts",
                     "line": 158,
                     "character": 11,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L158"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -14476,7 +15192,7 @@
                 "fileName": "environment.ts",
                 "line": 192,
                 "character": 13,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L192"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -14493,7 +15209,7 @@
                     "fileName": "environment.ts",
                     "line": 192,
                     "character": 13,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L192"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -14558,7 +15274,7 @@
                 "fileName": "environment.ts",
                 "line": 88,
                 "character": 12,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L88"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -14575,7 +15291,7 @@
                     "fileName": "environment.ts",
                     "line": 88,
                     "character": 12,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L88"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -14606,7 +15322,7 @@
                 "fileName": "environment.ts",
                 "line": 203,
                 "character": 13,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L203"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -14623,7 +15339,7 @@
                     "fileName": "environment.ts",
                     "line": 203,
                     "character": 13,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L203"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -14688,7 +15404,7 @@
                 "fileName": "environment.ts",
                 "line": 162,
                 "character": 14,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L162"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -14705,7 +15421,7 @@
                     "fileName": "environment.ts",
                     "line": 162,
                     "character": 14,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L162"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -14770,7 +15486,7 @@
                 "fileName": "environment.ts",
                 "line": 196,
                 "character": 16,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L196"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -14787,7 +15503,7 @@
                     "fileName": "environment.ts",
                     "line": 196,
                     "character": 16,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L196"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -14852,7 +15568,7 @@
                 "fileName": "environment.ts",
                 "line": 92,
                 "character": 15,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L92"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -14869,7 +15585,7 @@
                     "fileName": "environment.ts",
                     "line": 92,
                     "character": 15,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L92"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -14900,7 +15616,7 @@
                 "fileName": "environment.ts",
                 "line": 225,
                 "character": 8,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L225"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -14917,14 +15633,14 @@
                     "fileName": "environment.ts",
                     "line": 225,
                     "character": 8,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L225"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "object",
                   "declaration": {
-                    "id": "616",
+                    "id": "629",
                     "type": "type-literal",
                     "attributes": {
                       "name": "__type",
@@ -14939,7 +15655,7 @@
                           "fileName": "environment.ts",
                           "line": 225,
                           "character": 11,
-                          "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L225"
+                          "url": null
                         }
                       ],
                       "variables": [
@@ -14964,7 +15680,7 @@
                               "fileName": "environment.ts",
                               "line": 225,
                               "character": 20,
-                              "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L225"
+                              "url": null
                             }
                           ],
                           "typeInfo": {
@@ -14993,7 +15709,7 @@
                               "fileName": "environment.ts",
                               "line": 225,
                               "character": 42,
-                              "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L225"
+                              "url": null
                             }
                           ],
                           "typeInfo": {
@@ -15019,7 +15735,7 @@
                         "fileName": "environment.ts",
                         "line": 225,
                         "character": 11,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L225"
+                        "url": null
                       }
                     ],
                     "variables": [
@@ -15044,7 +15760,7 @@
                             "fileName": "environment.ts",
                             "line": 225,
                             "character": 20,
-                            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L225"
+                            "url": null
                           }
                         ],
                         "typeInfo": {
@@ -15073,7 +15789,7 @@
                             "fileName": "environment.ts",
                             "line": 225,
                             "character": 42,
-                            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L225"
+                            "url": null
                           }
                         ],
                         "typeInfo": {
@@ -15108,7 +15824,7 @@
                 "fileName": "environment.ts",
                 "line": 95,
                 "character": 12,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L95"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -15125,7 +15841,7 @@
                     "fileName": "environment.ts",
                     "line": 95,
                     "character": 12,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L95"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -15198,7 +15914,7 @@
                   "isArray": false,
                   "name": "object",
                   "declaration": {
-                    "id": "668",
+                    "id": "681",
                     "type": "type-literal",
                     "attributes": {
                       "name": "__type",
@@ -15382,7 +16098,7 @@
                 "fileName": "environment.ts",
                 "line": 81,
                 "character": 16,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L81"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -15399,7 +16115,7 @@
                     "fileName": "environment.ts",
                     "line": 81,
                     "character": 16,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L81"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -15448,7 +16164,7 @@
                 "fileName": "environment.ts",
                 "line": 134,
                 "character": 19,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L134"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -15465,7 +16181,7 @@
                     "fileName": "environment.ts",
                     "line": 134,
                     "character": 19,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L134"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -15562,7 +16278,7 @@
                 "fileName": "environment.ts",
                 "line": 183,
                 "character": 16,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L183"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -15579,7 +16295,7 @@
                     "fileName": "environment.ts",
                     "line": 183,
                     "character": 16,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L183"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -15896,7 +16612,7 @@
                 "fileName": "environment.ts",
                 "line": 64,
                 "character": 15,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L64"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -15913,14 +16629,14 @@
                     "fileName": "environment.ts",
                     "line": 64,
                     "character": 15,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L64"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "Environment",
                   "link": {
-                    "id": "554",
+                    "id": "567",
                     "type": "class",
                     "slug": "environment",
                     "sources": [
@@ -15928,11 +16644,11 @@
                         "fileName": "environment.ts",
                         "line": 57,
                         "character": 32,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L57"
+                        "url": null
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -15955,7 +16671,7 @@
                       "isArray": false,
                       "name": "EnvironmentOptions",
                       "link": {
-                        "id": "540",
+                        "id": "553",
                         "type": "interface",
                         "slug": "environmentoptions",
                         "sources": [
@@ -15963,11 +16679,11 @@
                             "fileName": "environment.ts",
                             "line": 41,
                             "character": 35,
-                            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L41"
+                            "url": null
                           }
                         ],
                         "parent": {
-                          "id": "317",
+                          "id": "330",
                           "type": "0",
                           "slug": "_glimmer_application",
                           "sources": null
@@ -15983,7 +16699,7 @@
       }
     },
     {
-      "id": "519",
+      "id": "532",
       "type": "class",
       "attributes": {
         "name": "HelperReference",
@@ -16013,7 +16729,7 @@
             "fileName": "helpers/user-helper.ts",
             "line": 44,
             "character": 28,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L44"
+            "url": null
           }
         ],
         "constructors": [
@@ -16038,7 +16754,7 @@
                 "fileName": "helpers/user-helper.ts",
                 "line": 47,
                 "character": 28,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L47"
+                "url": null
               }
             ],
             "constructorSignatures": [
@@ -16055,14 +16771,14 @@
                     "fileName": "helpers/user-helper.ts",
                     "line": 47,
                     "character": 28,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L47"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "HelperReference",
                   "link": {
-                    "id": "519",
+                    "id": "532",
                     "type": "class",
                     "slug": "helperreference",
                     "sources": [
@@ -16070,11 +16786,11 @@
                         "fileName": "helpers/user-helper.ts",
                         "line": 44,
                         "character": 28,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L44"
+                        "url": null
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -16097,7 +16813,7 @@
                       "isArray": false,
                       "name": "UserHelper",
                       "link": {
-                        "id": "532",
+                        "id": "545",
                         "type": "type-alias",
                         "slug": "userhelper",
                         "sources": [
@@ -16105,11 +16821,11 @@
                             "fileName": "helpers/user-helper.ts",
                             "line": 19,
                             "character": 22,
-                            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L19"
+                            "url": null
                           }
                         ],
                         "parent": {
-                          "id": "317",
+                          "id": "330",
                           "type": "0",
                           "slug": "_glimmer_application",
                           "sources": null
@@ -16160,7 +16876,7 @@
                 "fileName": "helpers/user-helper.ts",
                 "line": 46,
                 "character": 14,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L46"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -16189,14 +16905,14 @@
                 "fileName": "helpers/user-helper.ts",
                 "line": 45,
                 "character": 16,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L45"
+                "url": null
               }
             ],
             "typeInfo": {
               "isArray": false,
               "name": "UserHelper",
               "link": {
-                "id": "532",
+                "id": "545",
                 "type": "type-alias",
                 "slug": "userhelper",
                 "sources": [
@@ -16204,11 +16920,11 @@
                     "fileName": "helpers/user-helper.ts",
                     "line": 19,
                     "character": 22,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L19"
+                    "url": null
                   }
                 ],
                 "parent": {
-                  "id": "317",
+                  "id": "330",
                   "type": "0",
                   "slug": "_glimmer_application",
                   "sources": null
@@ -16237,7 +16953,7 @@
                 "fileName": "helpers/user-helper.ts",
                 "line": 47,
                 "character": 12,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L47"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -16268,7 +16984,7 @@
                 "fileName": "helpers/user-helper.ts",
                 "line": 60,
                 "character": 5,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L60"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -16285,14 +17001,14 @@
                     "fileName": "helpers/user-helper.ts",
                     "line": 60,
                     "character": 5,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L60"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "SimplePathReference",
                   "link": {
-                    "id": "505",
+                    "id": "518",
                     "type": "class",
                     "slug": "simplepathreference",
                     "sources": [
@@ -16300,11 +17016,11 @@
                         "fileName": "helpers/user-helper.ts",
                         "line": 25,
                         "character": 32,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L25"
+                        "url": null
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -16353,7 +17069,7 @@
                 "fileName": "helpers/user-helper.ts",
                 "line": 54,
                 "character": 7,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L54"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -16370,7 +17086,7 @@
                     "fileName": "helpers/user-helper.ts",
                     "line": 54,
                     "character": 7,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L54"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -16384,7 +17100,7 @@
       }
     },
     {
-      "id": "415",
+      "id": "428",
       "type": "class",
       "attributes": {
         "name": "Iterable",
@@ -16414,7 +17130,7 @@
             "fileName": "iterable.ts",
             "line": 91,
             "character": 29,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L91"
+            "url": null
           }
         ],
         "constructors": [
@@ -16439,7 +17155,7 @@
                 "fileName": "iterable.ts",
                 "line": 94,
                 "character": 33,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L94"
+                "url": null
               }
             ],
             "constructorSignatures": [
@@ -16456,14 +17172,14 @@
                     "fileName": "iterable.ts",
                     "line": 94,
                     "character": 33,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L94"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "Iterable",
                   "link": {
-                    "id": "415",
+                    "id": "428",
                     "type": "class",
                     "slug": "iterable",
                     "sources": [
@@ -16471,11 +17187,11 @@
                         "fileName": "iterable.ts",
                         "line": 91,
                         "character": 29,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L91"
+                        "url": null
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -16514,7 +17230,7 @@
                       "isArray": false,
                       "name": "KeyFor",
                       "link": {
-                        "id": "439",
+                        "id": "452",
                         "type": "type-alias",
                         "slug": "keyfor",
                         "sources": [
@@ -16522,17 +17238,17 @@
                             "fileName": "iterable.ts",
                             "line": 17,
                             "character": 18,
-                            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L17"
+                            "url": null
                           },
                           {
                             "fileName": "environment.ts",
                             "line": 39,
                             "character": 11,
-                            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L39"
+                            "url": null
                           }
                         ],
                         "parent": {
-                          "id": "317",
+                          "id": "330",
                           "type": "0",
                           "slug": "_glimmer_application",
                           "sources": null
@@ -16567,14 +17283,14 @@
                 "fileName": "iterable.ts",
                 "line": 94,
                 "character": 16,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L94"
+                "url": null
               }
             ],
             "typeInfo": {
               "isArray": false,
               "name": "KeyFor",
               "link": {
-                "id": "439",
+                "id": "452",
                 "type": "type-alias",
                 "slug": "keyfor",
                 "sources": [
@@ -16582,17 +17298,17 @@
                     "fileName": "iterable.ts",
                     "line": 17,
                     "character": 18,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L17"
+                    "url": null
                   },
                   {
                     "fileName": "environment.ts",
                     "line": 39,
                     "character": 11,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L39"
+                    "url": null
                   }
                 ],
                 "parent": {
-                  "id": "317",
+                  "id": "330",
                   "type": "0",
                   "slug": "_glimmer_application",
                   "sources": null
@@ -16621,7 +17337,7 @@
                 "fileName": "iterable.ts",
                 "line": 93,
                 "character": 13,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L93"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -16650,7 +17366,7 @@
                 "fileName": "iterable.ts",
                 "line": 92,
                 "character": 12,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L92"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -16681,7 +17397,7 @@
                 "fileName": "iterable.ts",
                 "line": 102,
                 "character": 9,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L102"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -16698,7 +17414,7 @@
                     "fileName": "iterable.ts",
                     "line": 102,
                     "character": 9,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L102"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -16729,7 +17445,7 @@
                 "fileName": "iterable.ts",
                 "line": 133,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L133"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -16746,7 +17462,7 @@
                     "fileName": "iterable.ts",
                     "line": 133,
                     "character": 18,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L133"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -16795,7 +17511,7 @@
                 "fileName": "iterable.ts",
                 "line": 137,
                 "character": 21,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L137"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -16812,7 +17528,7 @@
                     "fileName": "iterable.ts",
                     "line": 137,
                     "character": 21,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L137"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -16877,7 +17593,7 @@
                 "fileName": "iterable.ts",
                 "line": 129,
                 "character": 22,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L129"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -16894,7 +17610,7 @@
                     "fileName": "iterable.ts",
                     "line": 129,
                     "character": 22,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L129"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -16959,7 +17675,7 @@
                 "fileName": "iterable.ts",
                 "line": 125,
                 "character": 19,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L125"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -16976,7 +17692,7 @@
                     "fileName": "iterable.ts",
                     "line": 125,
                     "character": 19,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L125"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -17008,7 +17724,7 @@
       }
     },
     {
-      "id": "396",
+      "id": "409",
       "type": "class",
       "attributes": {
         "name": "ObjectKeysIterator",
@@ -17038,7 +17754,7 @@
             "fileName": "iterable.ts",
             "line": 48,
             "character": 24,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L48"
+            "url": null
           }
         ],
         "constructors": [
@@ -17063,7 +17779,7 @@
                 "fileName": "iterable.ts",
                 "line": 52,
                 "character": 23,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L52"
+                "url": null
               }
             ],
             "constructorSignatures": [
@@ -17080,14 +17796,14 @@
                     "fileName": "iterable.ts",
                     "line": 52,
                     "character": 23,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L52"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "ObjectKeysIterator",
                   "link": {
-                    "id": "396",
+                    "id": "409",
                     "type": "class",
                     "slug": "objectkeysiterator",
                     "sources": [
@@ -17095,11 +17811,11 @@
                         "fileName": "iterable.ts",
                         "line": 48,
                         "character": 24,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L48"
+                        "url": null
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -17154,7 +17870,7 @@
                       "isArray": false,
                       "name": "KeyFor",
                       "link": {
-                        "id": "439",
+                        "id": "452",
                         "type": "type-alias",
                         "slug": "keyfor",
                         "sources": [
@@ -17162,17 +17878,17 @@
                             "fileName": "iterable.ts",
                             "line": 17,
                             "character": 18,
-                            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L17"
+                            "url": null
                           },
                           {
                             "fileName": "environment.ts",
                             "line": 39,
                             "character": 11,
-                            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L39"
+                            "url": null
                           }
                         ],
                         "parent": {
-                          "id": "317",
+                          "id": "330",
                           "type": "0",
                           "slug": "_glimmer_application",
                           "sources": null
@@ -17207,14 +17923,14 @@
                 "fileName": "iterable.ts",
                 "line": 51,
                 "character": 16,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L51"
+                "url": null
               }
             ],
             "typeInfo": {
               "isArray": false,
               "name": "KeyFor",
               "link": {
-                "id": "439",
+                "id": "452",
                 "type": "type-alias",
                 "slug": "keyfor",
                 "sources": [
@@ -17222,17 +17938,17 @@
                     "fileName": "iterable.ts",
                     "line": 17,
                     "character": 18,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L17"
+                    "url": null
                   },
                   {
                     "fileName": "environment.ts",
                     "line": 39,
                     "character": 11,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L39"
+                    "url": null
                   }
                 ],
                 "parent": {
-                  "id": "317",
+                  "id": "330",
                   "type": "0",
                   "slug": "_glimmer_application",
                   "sources": null
@@ -17261,7 +17977,7 @@
                 "fileName": "iterable.ts",
                 "line": 49,
                 "character": 14,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L49"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -17290,7 +18006,7 @@
                 "fileName": "iterable.ts",
                 "line": 52,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L52"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -17319,7 +18035,7 @@
                 "fileName": "iterable.ts",
                 "line": 50,
                 "character": 16,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L50"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -17350,7 +18066,7 @@
                 "fileName": "iterable.ts",
                 "line": 60,
                 "character": 9,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L60"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -17367,7 +18083,7 @@
                     "fileName": "iterable.ts",
                     "line": 60,
                     "character": 9,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L60"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -17398,7 +18114,7 @@
                 "fileName": "iterable.ts",
                 "line": 64,
                 "character": 6,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L64"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -17415,7 +18131,7 @@
                     "fileName": "iterable.ts",
                     "line": 64,
                     "character": 6,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/iterable.ts#L64"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -17429,7 +18145,7 @@
       }
     },
     {
-      "id": "505",
+      "id": "518",
       "type": "class",
       "attributes": {
         "name": "SimplePathReference",
@@ -17459,7 +18175,7 @@
             "fileName": "helpers/user-helper.ts",
             "line": 25,
             "character": 32,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L25"
+            "url": null
           }
         ],
         "typeParameters": [
@@ -17495,7 +18211,7 @@
                 "fileName": "helpers/user-helper.ts",
                 "line": 28,
                 "character": 28,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L28"
+                "url": null
               }
             ],
             "constructorSignatures": [
@@ -17512,14 +18228,14 @@
                     "fileName": "helpers/user-helper.ts",
                     "line": 28,
                     "character": 28,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L28"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
                   "isArray": false,
                   "name": "SimplePathReference",
                   "link": {
-                    "id": "505",
+                    "id": "518",
                     "type": "class",
                     "slug": "simplepathreference",
                     "sources": [
@@ -17527,11 +18243,11 @@
                         "fileName": "helpers/user-helper.ts",
                         "line": 25,
                         "character": 32,
-                        "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L25"
+                        "url": null
                       }
                     ],
                     "parent": {
-                      "id": "317",
+                      "id": "330",
                       "type": "0",
                       "slug": "_glimmer_application",
                       "sources": null
@@ -17598,7 +18314,7 @@
                 "fileName": "helpers/user-helper.ts",
                 "line": 26,
                 "character": 16,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L26"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -17627,7 +18343,7 @@
                 "fileName": "helpers/user-helper.ts",
                 "line": 27,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L27"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -17656,7 +18372,7 @@
                 "fileName": "helpers/user-helper.ts",
                 "line": 28,
                 "character": 12,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L28"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -17687,7 +18403,7 @@
                 "fileName": "helpers/user-helper.ts",
                 "line": 39,
                 "character": 5,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L39"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -17704,7 +18420,7 @@
                     "fileName": "helpers/user-helper.ts",
                     "line": 39,
                     "character": 5,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L39"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -17753,7 +18469,7 @@
                 "fileName": "helpers/user-helper.ts",
                 "line": 35,
                 "character": 7,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L35"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -17770,7 +18486,7 @@
                     "fileName": "helpers/user-helper.ts",
                     "line": 35,
                     "character": 7,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L35"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -17784,7 +18500,7 @@
       }
     },
     {
-      "id": "693",
+      "id": "707",
       "type": "interface",
       "attributes": {
         "name": "AppRoot",
@@ -17806,7 +18522,7 @@
         "sources": [
           {
             "fileName": "application.ts",
-            "line": 38,
+            "line": 40,
             "character": 24,
             "url": null
           }
@@ -17831,7 +18547,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 40,
+                "line": 42,
                 "character": 11,
                 "url": null
               }
@@ -17870,7 +18586,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 39,
+                "line": 41,
                 "character": 4,
                 "url": null
               }
@@ -17899,7 +18615,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 42,
+                "line": 44,
                 "character": 13,
                 "url": null
               }
@@ -17928,7 +18644,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 41,
+                "line": 43,
                 "character": 8,
                 "url": null
               }
@@ -17942,7 +18658,7 @@
       }
     },
     {
-      "id": "685",
+      "id": "698",
       "type": "interface",
       "attributes": {
         "name": "ApplicationOptions",
@@ -17959,17 +18675,46 @@
         },
         "alias": "applicationoptions",
         "fullName": "ApplicationOptions",
-        "hierarchy": "Interface ApplicationOptions\n  Property resolver:Resolver\n  Property rootName:string",
+        "hierarchy": "Interface ApplicationOptions\n  Property document:Document\n  Property resolver:Resolver\n  Property rootName:string",
         "kindString": "Interface",
         "sources": [
           {
             "fileName": "application.ts",
-            "line": 28,
+            "line": 29,
             "character": 35,
             "url": null
           }
         ],
         "properties": [
+          {
+            "name": "document",
+            "slug": "document",
+            "flags": {
+              "isExported": true,
+              "isExternal": false,
+              "isOptional": true,
+              "isPrivate": false,
+              "isPublic": false,
+              "isProtected": false,
+              "isStatic": false
+            },
+            "alias": "document",
+            "fullName": "ApplicationOptions.document",
+            "hierarchy": "Property document:Document",
+            "kindString": "Property",
+            "sources": [
+              {
+                "fileName": "application.ts",
+                "line": 32,
+                "character": 10,
+                "url": null
+              }
+            ],
+            "typeInfo": {
+              "isArray": false,
+              "name": "Document"
+            }
+          },
           {
             "name": "resolver",
             "slug": "resolver",
@@ -17989,7 +18734,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 30,
+                "line": 31,
                 "character": 10,
                 "url": null
               }
@@ -18018,7 +18763,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 29,
+                "line": 30,
                 "character": 10,
                 "url": null
               }
@@ -18032,7 +18777,7 @@
       }
     },
     {
-      "id": "450",
+      "id": "463",
       "type": "interface",
       "attributes": {
         "name": "ComponentDefinitionCreator",
@@ -18056,7 +18801,7 @@
             "fileName": "component-definition-creator.ts",
             "line": 5,
             "character": 36,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/component-definition-creator.ts#L5"
+            "url": null
           }
         ],
         "methods": [
@@ -18081,7 +18826,7 @@
                 "fileName": "component-definition-creator.ts",
                 "line": 6,
                 "character": 27,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/component-definition-creator.ts#L6"
+                "url": null
               }
             ],
             "callSignatures": [
@@ -18098,7 +18843,7 @@
                     "fileName": "component-definition-creator.ts",
                     "line": 6,
                     "character": 27,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/component-definition-creator.ts#L6"
+                    "url": null
                   }
                 ],
                 "typeInfo": {
@@ -18162,7 +18907,7 @@
       }
     },
     {
-      "id": "540",
+      "id": "553",
       "type": "interface",
       "attributes": {
         "name": "EnvironmentOptions",
@@ -18186,7 +18931,7 @@
             "fileName": "environment.ts",
             "line": 41,
             "character": 35,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L41"
+            "url": null
           }
         ],
         "properties": [
@@ -18211,7 +18956,7 @@
                 "fileName": "environment.ts",
                 "line": 43,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L43"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -18240,7 +18985,7 @@
                 "fileName": "environment.ts",
                 "line": 42,
                 "character": 10,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L42"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -18252,7 +18997,7 @@
       }
     },
     {
-      "id": "445",
+      "id": "458",
       "type": "interface",
       "attributes": {
         "name": "ExtendedTemplateMeta",
@@ -18282,7 +19027,7 @@
             "fileName": "template-meta.ts",
             "line": 3,
             "character": 30,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/template-meta.ts#L3"
+            "url": null
           }
         ],
         "properties": [
@@ -18336,7 +19081,7 @@
                 "fileName": "template-meta.ts",
                 "line": 5,
                 "character": 11,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/template-meta.ts#L5"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -18394,7 +19139,7 @@
                 "fileName": "template-meta.ts",
                 "line": 4,
                 "character": 11,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/template-meta.ts#L4"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -18406,7 +19151,7 @@
       }
     },
     {
-      "id": "688",
+      "id": "702",
       "type": "interface",
       "attributes": {
         "name": "Initializer",
@@ -18428,7 +19173,7 @@
         "sources": [
           {
             "fileName": "application.ts",
-            "line": 33,
+            "line": 35,
             "character": 28,
             "url": null
           }
@@ -18453,7 +19198,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 34,
+                "line": 36,
                 "character": 6,
                 "url": null
               }
@@ -18484,7 +19229,7 @@
             "sources": [
               {
                 "fileName": "application.ts",
-                "line": 35,
+                "line": 37,
                 "character": 12,
                 "url": null
               }
@@ -18501,7 +19246,7 @@
                 "sources": [
                   {
                     "fileName": "application.ts",
-                    "line": 35,
+                    "line": 37,
                     "character": 12,
                     "url": null
                   }
@@ -18535,7 +19280,60 @@
       }
     },
     {
-      "id": "470",
+      "id": "771",
+      "type": "function",
+      "attributes": {
+        "name": "NOOP",
+        "slug": "noop",
+        "flags": {
+          "isNormalized": true,
+          "isExported": false,
+          "isExternal": false,
+          "isOptional": false,
+          "isPrivate": false,
+          "isPublic": false,
+          "isProtected": false,
+          "isStatic": false
+        },
+        "alias": "noop",
+        "fullName": "NOOP",
+        "hierarchy": "Function NOOP\n  CallSignature NOOP:void",
+        "kindString": "Function",
+        "sources": [
+          {
+            "fileName": "application.ts",
+            "line": 27,
+            "character": 13,
+            "url": null
+          }
+        ],
+        "callSignatures": [
+          {
+            "name": "NOOP",
+            "slug": "noop-1",
+            "flags": {},
+            "alias": "noop-1",
+            "fullName": "NOOP.NOOP",
+            "hierarchy": "CallSignature NOOP:void",
+            "kindString": "Call signature",
+            "sources": [
+              {
+                "fileName": "application.ts",
+                "line": 27,
+                "character": 13,
+                "url": null
+              }
+            ],
+            "typeInfo": {
+              "isArray": false,
+              "name": "void"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "483",
       "type": "function",
       "attributes": {
         "name": "blockComponentMacro",
@@ -18559,7 +19357,7 @@
             "fileName": "dynamic-component.ts",
             "line": 21,
             "character": 35,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L21"
+            "url": null
           }
         ],
         "callSignatures": [
@@ -18576,7 +19374,7 @@
                 "fileName": "dynamic-component.ts",
                 "line": 21,
                 "character": 35,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L21"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -18670,7 +19468,7 @@
       }
     },
     {
-      "id": "491",
+      "id": "504",
       "type": "function",
       "attributes": {
         "name": "buildAction",
@@ -18694,7 +19492,7 @@
             "fileName": "helpers/action.ts",
             "line": 4,
             "character": 35,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/action.ts#L4"
+            "url": null
           }
         ],
         "callSignatures": [
@@ -18711,7 +19509,7 @@
                 "fileName": "helpers/action.ts",
                 "line": 4,
                 "character": 35,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/action.ts#L4"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -18757,7 +19555,7 @@
       }
     },
     {
-      "id": "537",
+      "id": "550",
       "type": "function",
       "attributes": {
         "name": "buildUserHelper",
@@ -18781,7 +19579,7 @@
             "fileName": "helpers/user-helper.ts",
             "line": 21,
             "character": 39,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L21"
+            "url": null
           }
         ],
         "callSignatures": [
@@ -18798,7 +19596,7 @@
                 "fileName": "helpers/user-helper.ts",
                 "line": 21,
                 "character": 39,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/user-helper.ts#L21"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -18828,7 +19626,7 @@
       }
     },
     {
-      "id": "682",
+      "id": "695",
       "type": "function",
       "attributes": {
         "name": "canCreateComponentDefinition",
@@ -18852,7 +19650,7 @@
             "fileName": "environment.ts",
             "line": 239,
             "character": 37,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L239"
+            "url": null
           }
         ],
         "callSignatures": [
@@ -18869,7 +19667,7 @@
                 "fileName": "environment.ts",
                 "line": 239,
                 "character": 37,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L239"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -18896,7 +19694,7 @@
                       "isArray": false,
                       "name": "ComponentDefinitionCreator",
                       "link": {
-                        "id": "450",
+                        "id": "463",
                         "type": "interface",
                         "slug": "componentdefinitioncreator",
                         "sources": [
@@ -18904,11 +19702,11 @@
                             "fileName": "component-definition-creator.ts",
                             "line": 5,
                             "character": 36,
-                            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/component-definition-creator.ts#L5"
+                            "url": null
                           }
                         ],
                         "parent": {
-                          "id": "317",
+                          "id": "330",
                           "type": "0",
                           "slug": "_glimmer_application",
                           "sources": null
@@ -18928,7 +19726,7 @@
       }
     },
     {
-      "id": "499",
+      "id": "512",
       "type": "function",
       "attributes": {
         "name": "debugInfoForReference",
@@ -18952,7 +19750,7 @@
             "fileName": "helpers/action.ts",
             "line": 32,
             "character": 37,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/action.ts#L32"
+            "url": null
           }
         ],
         "callSignatures": [
@@ -18969,7 +19767,7 @@
                 "fileName": "helpers/action.ts",
                 "line": 32,
                 "character": 37,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/action.ts#L32"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -18999,7 +19797,7 @@
       }
     },
     {
-      "id": "502",
+      "id": "515",
       "type": "function",
       "attributes": {
         "name": "debugName",
@@ -19023,7 +19821,7 @@
             "fileName": "helpers/action.ts",
             "line": 54,
             "character": 18,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/action.ts#L54"
+            "url": null
           }
         ],
         "callSignatures": [
@@ -19040,7 +19838,7 @@
                 "fileName": "helpers/action.ts",
                 "line": 54,
                 "character": 18,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/action.ts#L54"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -19070,7 +19868,7 @@
       }
     },
     {
-      "id": "483",
+      "id": "496",
       "type": "function",
       "attributes": {
         "name": "dynamicComponentFor",
@@ -19094,7 +19892,7 @@
             "fileName": "dynamic-component.ts",
             "line": 39,
             "character": 28,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L39"
+            "url": null
           }
         ],
         "callSignatures": [
@@ -19111,14 +19909,14 @@
                 "fileName": "dynamic-component.ts",
                 "line": 39,
                 "character": 28,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L39"
+                "url": null
               }
             ],
             "typeInfo": {
               "isArray": false,
               "name": "DynamicComponentReference",
               "link": {
-                "id": "456",
+                "id": "469",
                 "type": "class",
                 "slug": "dynamiccomponentreference",
                 "sources": [
@@ -19126,11 +19924,11 @@
                     "fileName": "dynamic-component.ts",
                     "line": 46,
                     "character": 31,
-                    "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L46"
+                    "url": null
                   }
                 ],
                 "parent": {
-                  "id": "317",
+                  "id": "330",
                   "type": "0",
                   "slug": "_glimmer_application",
                   "sources": null
@@ -19192,7 +19990,7 @@
       }
     },
     {
-      "id": "488",
+      "id": "501",
       "type": "function",
       "attributes": {
         "name": "hashToArgs",
@@ -19216,7 +20014,7 @@
             "fileName": "dynamic-component.ts",
             "line": 70,
             "character": 19,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L70"
+            "url": null
           }
         ],
         "callSignatures": [
@@ -19233,7 +20031,7 @@
                 "fileName": "dynamic-component.ts",
                 "line": 70,
                 "character": 19,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L70"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -19263,7 +20061,7 @@
       }
     },
     {
-      "id": "477",
+      "id": "490",
       "type": "function",
       "attributes": {
         "name": "inlineComponentMacro",
@@ -19287,7 +20085,7 @@
             "fileName": "dynamic-component.ts",
             "line": 30,
             "character": 36,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L30"
+            "url": null
           }
         ],
         "callSignatures": [
@@ -19304,7 +20102,7 @@
                 "fileName": "dynamic-component.ts",
                 "line": 30,
                 "character": 36,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/dynamic-component.ts#L30"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -19382,7 +20180,7 @@
       }
     },
     {
-      "id": "367",
+      "id": "380",
       "type": "function",
       "attributes": {
         "name": "isTypeSpecifier",
@@ -19453,7 +20251,7 @@
       }
     },
     {
-      "id": "678",
+      "id": "691",
       "type": "function",
       "attributes": {
         "name": "populateMacros",
@@ -19477,7 +20275,7 @@
             "fileName": "environment.ts",
             "line": 234,
             "character": 23,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L234"
+            "url": null
           }
         ],
         "callSignatures": [
@@ -19494,7 +20292,7 @@
                 "fileName": "environment.ts",
                 "line": 234,
                 "character": 23,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/environment.ts#L234"
+                "url": null
               }
             ],
             "typeInfo": {
@@ -19540,7 +20338,7 @@
       }
     },
     {
-      "id": "495",
+      "id": "508",
       "type": "function",
       "attributes": {
         "name": "throwNoActionError",
@@ -19564,7 +20362,7 @@
             "fileName": "helpers/action.ts",
             "line": 27,
             "character": 27,
-            "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/action.ts#L27"
+            "url": null
           }
         ],
         "callSignatures": [
@@ -19581,7 +20379,7 @@
                 "fileName": "helpers/action.ts",
                 "line": 27,
                 "character": 27,
-                "url": "https://github.com/glimmerjs/glimmer-application/blob/ab53a6d/src/helpers/action.ts#L27"
+                "url": null
               }
             ],
             "typeInfo": {


### PR DESCRIPTION
This fixes the docs generation script by running `yarn --pure-lockfile` for each of the doc repositories. This is necessary as the docs might reference dependencies that have to be present - otherwise we run into errors like

```
Cannot find module '@glimmer/env'
```

and the respective project is removed from the generated docs.