### PR TITLE
fix service worker so we can update the app

### DIFF
--- a/workers/service.ts
+++ b/workers/service.ts
@@ -1,9 +1,13 @@
+var rootURL = '/api/';
+var documentRegExp = new RegExp('/api/($|projects)');
+
 var CACHE_NAME = 'glimmer-api-docs';
-var urlsToCache = [
+var URLS_TO_CACHE = [
   '/api/',
   'app.css',
   'app.js',
   'assets/docs/main.js',
+  'assets/images/logo.png',
   'https://cdnjs.cloudflare.com/ajax/libs/markdown-it/8.3.1/markdown-it.js',
   'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/highlight.min.js',
   'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/languages/typescript.min.js',
@@ -16,25 +20,39 @@ self.addEventListener('install', function(event) {
     caches.open(CACHE_NAME)
       .then(function(cache) {
         console.log('Opened cache');
-        return cache.addAll(urlsToCache);
+        return cache.addAll(URLS_TO_CACHE);
       })
   );
 });
 
 self.addEventListener('fetch', function(event) {
   let request = event.request;
-  if (/api\/projects\//.test(request.url)) {
-    request = new Request('/api/');
+  if (documentRegExp.test(request.url)) {
+    // map all document requests to the root URL
+    // (as routes are only handled once the app is loaded)
+    request = new Request(rootURL);
+
+    // document requests are using the cache as a
+    // fallback so we can ship new version of the app
+    event.respondWith(
+      fetch(request)
+        // Request failed - fall back to cache
+        .catch(function() {
+          return caches.match(request);
+        })
+    );
+  } else {
+    // asset requests can be handled using via the cache
+    // first as URLs are fingerprinted
+    event.respondWith(
+      caches.match(request)
+        .then(function(response) {
+          // Cache hit - return response
+          if (response) {
+            return response;
+          }
+          return fetch(request);
+        })
+    );
   }
-  event.respondWith(
-    caches.match(request)
-      .then(function(response) {
-        // Cache hit - return response
-        if (response) {
-          return response;
-        }
-        return fetch(request);
-      }
-    )
-  );
 });


### PR DESCRIPTION
I messed up the service worker implementation. We were handling all requests cache-first so that if the requested URL was found in the app cache it would be served from that. The problem with that is that we also cache documents (which we have to do so that we can run offline), which effectively means that anyone having the document cached locally would never see new versions of the app as the service worker would always return the cached version.

This changes the implementation so that we only serve assets from the cache first (which should be fine as assets are fingerprinted) and only serve documents from the cached when offline (the request fails).