### PR TITLE
Revert "Work on fixing api docs deploys"

### DIFF
--- a/bin/sync.sh
+++ b/bin/sync.sh
@@ -20,7 +20,7 @@ npm install node-sass --no-bin-links --no-save
 $ROOT_DIR/node_modules/.bin/ember build --environment=production
 mkdir -p tmp/build
 echo "cloning"
-git clone https://github.com/glimmerjs/glimmer-website.git tmp/build/glimmer-website 2>&1
+git clone https://ember-guides-deploy-bot:${GITHUB_TOKEN}@github.com/glimmerjs/glimmer-website.git tmp/build/glimmer-website 2>&1
 echo "done cloning"
 
 pushd tmp/build/glimmer-website


### PR DESCRIPTION
Reverts glimmerjs/glimmer-api-docs#25

After reading the deploy script some more, we actually need the token for deploying since it's doing a push to master on the glimmer website repo.

In order to fix the deploy, we'll need to generate a new GITHUB_TOKEN that has access to push to the glimmerjs/glimmer-website repo and update Travis CI with it.